### PR TITLE
Reliability: Top-level bot restart with exponential backoff on unexpected return w/o exception

### DIFF
--- a/KazTron.py
+++ b/KazTron.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
 
     loop = asyncio.get_event_loop()
     try:
-        bo_timer = runner.Backoff()
+        bo_timer = runner.Backoff(initial_time=3.0, base=1.58, max_attempts=12)
         wait_time = 0
         while True:
             reset_task = loop.call_later(wait_time, reset_backoff, bo_timer, bo_timer.n)

--- a/KazTron.py
+++ b/KazTron.py
@@ -5,9 +5,10 @@ import sys
 import asyncio
 import logging
 
-from discord.ext import commands
+import time
 
-from kaztron import cfg_defaults
+import kaztron
+from kaztron import runner
 from kaztron.config import get_kaztron_config
 from kaztron.utils.logging import setup_logging
 
@@ -18,49 +19,42 @@ from kaztron.utils.logging import setup_logging
 
 # load configuration
 try:
-    config = get_kaztron_config(cfg_defaults)
+    config = get_kaztron_config(kaztron.cfg_defaults)
 except OSError as e:
     print(str(e), file=sys.stderr)
-    sys.exit(1)
+    sys.exit(runner.ErrorCodes.CFG_FILE)
 
 # setup logging
 setup_logging(logging.getLogger(), config)  # setup the root logger
 logger = logging.getLogger("kaztron.bootstrap")
 
 
+def reset_backoff(backoff: runner.Backoff, sequence):
+    if sequence == backoff.n:  # don't do it if we had a retry in the meantime
+        backoff.reset()
+
+
 if __name__ == '__main__':
-    client = commands.Bot(command_prefix='.',
-        description='This an automated bot for the /r/worldbuilding discord server',
-        pm_help=True)
+    logger.info("Welcome to KazTron v{}, booting up...".format(kaztron.__version__))
 
-    # Load extensions
-    startup_extensions = config.get("core", "extensions")
-    client.load_extension("kaztron.cog.core")
-    for extension in startup_extensions:
-        # noinspection PyBroadException
-        try:
-            client.load_extension("kaztron.cog." + extension)
-        except Exception as e:
-            logger.exception('Failed to load extension {}'.format(extension))
-            sys.exit(1)
-
-    # Run the main loop
     loop = asyncio.get_event_loop()
-    # noinspection PyBroadException
     try:
-        loop.run_until_complete(client.login(config.get("discord", "token")))
-        loop.run_until_complete(client.connect())
-    except KeyboardInterrupt:
-        logger.info("Interrupted by user")
-        logger.info("Waiting for client to close...")
-        loop.run_until_complete(client.close())
-        logger.info("Client closed.")
-    except:
-        logger.exception("Uncaught exception during bot execution")
-        logger.error("Waiting for client to close...")
-        loop.run_until_complete(client.close())
-        logger.error("Client closed.")
+        bo_timer = runner.Backoff()
+        wait_time = 0
+        while True:
+            reset_task = loop.call_later(wait_time, reset_backoff, bo_timer, bo_timer.n)
+            runner.run(loop)
+            logger.error("Bot halted unexpectedly.")
+            reset_task.cancel()
+            wait_time = bo_timer.next()
+            logger.info("Restarting bot in {:.1f} seconds...".format(wait_time))
+            time.sleep(wait_time)
+            logger.info("Restarting bot...")
+    except StopIteration:
+        logger.error("Too many failed attempts. Exiting.")
+        sys.exit(runner.ErrorCodes.RETRY_MAX_ATTEMPTS)
+    except KeyboardInterrupt:  # outside of runner.run
+        logger.info("Interrupted by user. Exiting.")
     finally:
-        logger.info("Closing event loop...")
-        loop.close()
         logger.info("Exiting.")
+        loop.close()

--- a/kaztron/cog/core.py
+++ b/kaztron/cog/core.py
@@ -209,7 +209,7 @@ class CoreCog:
         """
         logger.debug("info(): {!s}".format(message_log_str(ctx.message)))
         em = discord.Embed(color=0x80AAFF)
-        em.set_author(name="KazTron %s" % kaztron.bot_info["version"])
+        em.set_author(name="KazTron v{}".format(kaztron.bot_info["version"]))
         em.add_field(name="Changelog", value=kaztron.bot_info["changelog"], inline=False)
         for title, url in kaztron.bot_info["links"].items():
             em.add_field(name=title, value="[Link]({})".format(url), inline=True)

--- a/kaztron/runner.py
+++ b/kaztron/runner.py
@@ -1,0 +1,99 @@
+import asyncio
+import enum
+import logging
+import random
+import sys
+
+from discord.ext import commands
+
+import kaztron
+from kaztron.config import get_kaztron_config
+
+logger = logging.getLogger("kaztron.bootstrap")
+
+
+class ErrorCodes:
+    OK = 0
+    ERROR = 1
+    EXTENSION_LOAD = 7
+    RETRY_MAX_ATTEMPTS = 8
+    CFG_FILE = 17
+
+
+def run(loop: asyncio.AbstractEventLoop):
+    config = get_kaztron_config()
+    client = commands.Bot(command_prefix='.',
+        description='This an automated bot for the /r/worldbuilding discord server',
+        pm_help=True)
+
+    # Load extensions
+    startup_extensions = config.get("core", "extensions")
+    client.load_extension("kaztron.cog.core")
+    for extension in startup_extensions:
+        logger.debug("Loading extension: {}".format(extension))
+        # noinspection PyBroadException
+        try:
+            client.load_extension("kaztron.cog." + extension)
+        except Exception as e:
+            logger.exception('Failed to load extension {}'.format(extension))
+            sys.exit(ErrorCodes.EXTENSION_LOAD)
+
+    # noinspection PyBroadException
+    try:
+        loop.run_until_complete(client.login(config.get("discord", "token")))
+        loop.run_until_complete(client.connect())
+    except KeyboardInterrupt:
+        logger.info("Interrupted by user")
+        logger.debug("Waiting for client to close...")
+        loop.run_until_complete(client.close())
+        logger.info("Client closed.")
+        sys.exit(ErrorCodes.OK)
+    except:
+        logger.exception("Uncaught exception during bot execution")
+        logger.debug("Waiting for client to close...")
+        loop.run_until_complete(client.close())
+        logger.info("Client closed.")
+        sys.exit(ErrorCodes.ERROR)
+    finally:
+        logger.debug("Cancelling pending tasks...")
+        # BEGIN CONTRIB
+        # Source: https://github.com/Rapptz/discord.py/blob/
+        # 09bd2f4de7cccbd5d33f61e5257e1d4dc96b5caa/discord/client.py#L517
+        #
+        # Copyright (c) 2015-2016 Rapptz. MIT licence.
+        pending = asyncio.Task.all_tasks(loop=loop)
+        gathered = asyncio.gather(*pending, loop=loop)
+        try:
+            gathered.cancel()
+            loop.run_until_complete(gathered)
+            gathered.exception()
+        except Exception:
+            pass
+        # END CONTRIB
+
+
+class Backoff:
+    """
+    Exponential backoff driver. Doubles retry time every failure.
+
+    :param initial_time: Retry time after first failure.
+    :param max_attempts: Maximum number of attempts before giving up.
+    """
+    def __init__(self, initial_time=1.0, max_attempts=8,):
+        self.t0 = initial_time
+        self.max = max_attempts
+        self.n = 0
+        self.reset()
+
+    def next(self):
+        """ Return the next wait time in seconds. Raises a RuntimeError if max attempts exceeded."""
+        if self.n < self.max:
+            tn = self.t0 * (2 ** self.n) + (random.randint(0, 1000) / 1000)
+            self.n += 1
+            return tn
+        else:
+            raise StopIteration("Maximum attempts exceeded")
+
+    def reset(self):
+        """ Reset the number of attempts. """
+        self.n = 0

--- a/kaztron/runner.py
+++ b/kaztron/runner.py
@@ -34,7 +34,7 @@ def run(loop: asyncio.AbstractEventLoop):
         # noinspection PyBroadException
         try:
             client.load_extension("kaztron.cog." + extension)
-        except Exception as e:
+        except Exception:
             logger.exception('Failed to load extension {}'.format(extension))
             sys.exit(ErrorCodes.EXTENSION_LOAD)
 
@@ -53,16 +53,22 @@ def run(loop: asyncio.AbstractEventLoop):
         logger.debug("Waiting for client to close...")
         loop.run_until_complete(client.close())
         logger.info("Client closed.")
-        sys.exit(ErrorCodes.ERROR)
+
+        # Let the external retry reboot the bot - attempt recovery from errors
+        # sys.exit(ErrorCodes.ERROR)
+        return
     finally:
         logger.debug("Cancelling pending tasks...")
         # BEGIN CONTRIB
+        # Modified from code from discord.py.
+        #
         # Source: https://github.com/Rapptz/discord.py/blob/
         # 09bd2f4de7cccbd5d33f61e5257e1d4dc96b5caa/discord/client.py#L517
         #
-        # Copyright (c) 2015-2016 Rapptz. MIT licence.
+        # Original code Copyright (c) 2015-2016 Rapptz. MIT licence.
         pending = asyncio.Task.all_tasks(loop=loop)
         gathered = asyncio.gather(*pending, loop=loop)
+        # noinspection PyBroadException
         try:
             gathered.cancel()
             loop.run_until_complete(gathered)
@@ -77,18 +83,20 @@ class Backoff:
     Exponential backoff driver. Doubles retry time every failure.
 
     :param initial_time: Retry time after first failure.
+    :param base: Exponential base. Default 2.0.
     :param max_attempts: Maximum number of attempts before giving up.
     """
-    def __init__(self, initial_time=1.0, max_attempts=8,):
+    def __init__(self, initial_time=1.0, base=2.0, max_attempts=8):
         self.t0 = initial_time
         self.max = max_attempts
+        self.base = base
         self.n = 0
         self.reset()
 
     def next(self):
         """ Return the next wait time in seconds. Raises a RuntimeError if max attempts exceeded."""
         if self.n < self.max:
-            tn = self.t0 * (2 ** self.n) + (random.randint(0, 1000) / 1000)
+            tn = self.t0 * (self.base ** self.n) + (random.randint(0, 1000) / 1000)
             self.n += 1
             return tn
         else:


### PR DESCRIPTION
This change attempts to mitigate #10 at the top level. As best as I've been able to tell, the failures have been unexpected websocket closures (opcode=8) incoming from the remote Discord server, so possibly not resolvable beyond just re-connecting as below.

When the bot's main task completes unexpectedly, we should restart the bot to ensure continued availability. All pending tasks on the event loop are cancelled in the meanwhile to ensure a clean loop.

KeyboardInterrupt will not cause the bot to restart, but exit cleanly. An exponential backoff is implemented for network-bound and resource-bound problems, attempting a maximum of 10 times over at least 8.5 minutes before giving up [1].

This is motivated by the fact that the bot appears not to appreciate an attempt to re-login() and re-connect() after the websocket has been closed (i.e. websocket raises). I don't see any nice ways of reinitialising except reinstantiating the bot.

At the moment, hard failures (max attempts, errors other than the "silent" error of issue #10) will not be communicated except via logging - a process monitoring daemon or agent on the host is recommended, as we've previously done before (e.g. systemd service appropriately configured, perhaps throw in an outgoing email) @cxcfme 

[1] (although websocket will tend to bubble up an exception and cause a failure in the case of a real network problem - this is maybe something to be discussed too, if we want to plug actual network failures into the backoff (and how - need to identify the actual exceptions being raised in that case).