### PR TITLE
v2.1.3

### DIFF
--- a/kaztron/__init__.py
+++ b/kaztron/__init__.py
@@ -2,7 +2,7 @@
 from collections import OrderedDict
 from .kazcog import KazCog
 
-__version__ = "2.1.1"
+__version__ = "2.1.3"
 
 bot_info = {
     "version": __version__,

--- a/kaztron/utils/converter.py
+++ b/kaztron/utils/converter.py
@@ -2,7 +2,7 @@ import discord
 from discord.ext import commands
 
 import kaztron.utils.datetime as utils_dt
-from kaztron.utils.discord import extract_user_id
+from kaztron.utils.discord import get_member
 
 
 class NaturalDateConverter(commands.Converter):
@@ -20,17 +20,12 @@ class NaturalDateConverter(commands.Converter):
         return date
 
 
-class MemberConverter2(commands.MemberConverter):
+class MemberConverter2(commands.Converter):
     """
     Member converter with slightly more tolerant ID inputs permitted.
     """
     def convert(self):
-        try:
-            s_user_id = extract_user_id(self.argument)
-        except discord.InvalidArgument:
-            s_user_id = self.argument
-        self.argument = s_user_id
-        return super().convert()
+        return get_member(self.ctx, self.argument)
 
 
 class NaturalInteger(commands.Converter):

--- a/kaztron/utils/discord.py
+++ b/kaztron/utils/discord.py
@@ -188,12 +188,7 @@ def get_member(ctx: commands.Context, user: str) -> discord.Member:
         s_user_id = user
 
     member_converter = commands.MemberConverter(ctx, s_user_id)
-    try:
-        return member_converter.convert()
-    except commands.BadArgument:
-        raise discord.InvalidArgument(
-            "User ID format {!r} is invalid or user not found".format(user)
-        )
+    return member_converter.convert()
 
 
 def get_command_prefix(ctx: commands.Context) -> str:


### PR DESCRIPTION
# Changelog

* [utils] Cleaned up MemberConverter2: makes use of get_member
* [utils] Fixed MemberConverter2/get_member should raise commands.BadArgument, not discord.InvalidArgument