### PR TITLE
2.2a2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # KazTron
 
-A python bot for r/worldbuilding Discord server.
+A Discord bot framework, currently in use at:
 
-## Documentation
-
-The manual can be found at https://worldbuilding.github.io/kaztron/
+* the /r/Worldbuilding Discord server ([manual](http://worldbuilding.network/kaztron))
+* the Inkblood Writing Guild Discord server ([manual](http://inkblood.arenthil.net))
+* the Writer Lounge Discord server
 
 ## Requirements
 
-* Minimum Python version: 3.5
+* Minimum Python version: 3.6
 * Dependencies: [requirements.txt](./requirements.txt)
 
 ## Development
 
 * [Development roadmap](https://github.com/Worldbuilding/KazTron/milestones)
-* Inquiries can be directed to /r/worldbuilding's modmail on reddit, or the #meta channel on our Discord server
-
+* Inquiries can be directed to /r/worldbuilding's modmail on reddit, or the #meta channel the /r/Worldbuilding Discord server.
+* Inkblood/Armarius-related inquiries should be directed to Laogeodritt/Laogeobunny on the #meta channel on Inkblood's Discord server. Do **not** direct these inquiries to Worldbuilding.

--- a/config.example.json
+++ b/config.example.json
@@ -111,6 +111,7 @@
   },
   "modtools": {
     "tempban_role": "Role Name Here",
+    "notif_role": "Name of role used to send notifications to all mods",
     "channel_mod": "ID of channel for mod notifications (like timed unbans)",
     "distinguish_map": {
       "mod-role1": "distinguish-role1",

--- a/config.example.json
+++ b/config.example.json
@@ -11,7 +11,7 @@
   },
   "core": {
     "name": "KazTronExampleBot",
-    "extensions": ["welcome", "wordfilter", "dice", "modtools", "spotlight", "role_man", "modnotes", "reminder", "sprint", "quotedb", "voicelog"],
+    "extensions": ["welcome", "wordfilter", "dice", "modtools", "spotlight", "modnotes", "reminder", "sprint", "quotedb", "voicelog"],
     "channel_request": "channel ID for requests",
     "info_links": {
       "link name 1": "http://potato.example/url/to/something",
@@ -38,7 +38,7 @@
       "discord": "INFO"
     }
   },
-  "role_man": {
+  "rolemanager": {
     "user_roles": {
       "role_name1": {
         "join_name": "join command name",

--- a/config.example.json
+++ b/config.example.json
@@ -74,8 +74,9 @@
     }
   },
   "blots": {
-    "check_in_weekday": 4,
-    "check_in_time": "5:00",
+    "check_in_period_weekdays": [2, 3],
+    "check_in_period_time": "5:00",
+    "check_in_window_exempt_roles": ["role name", "another role name"],
     "check_in_channel": "channel ID here",
     "milestone_map": {
       "words": {

--- a/config.example.json
+++ b/config.example.json
@@ -7,6 +7,7 @@
     "playing": "status (playing ...) message here",
     "token": "bot auth token",
     "channel_output": "channel ID for general bot messages (technical/audit mostly)",
+    "channel_public": "channel ID for public bot usage and some status/notification messages to users",
     "channel_test": "channel ID for general bot usage or testing purposes (mostly unused, some commands are allowed here as well as their normal allowed channels)"
   },
   "core": {

--- a/kaztron/__init__.py
+++ b/kaztron/__init__.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from .kazcog import KazCog
 from .scheduler import Scheduler, TaskInstance, task
 
-__version__ = "2.2a1"
+__version__ = "2.2a1.dev1"
 
 bot_info = {
     "version": __version__,

--- a/kaztron/cog/blots/badges.py
+++ b/kaztron/cog/blots/badges.py
@@ -6,7 +6,7 @@ from discord.ext import commands
 
 from kaztron import KazCog
 from kaztron.cog.blots import model
-from kaztron.cog.blots.controller import BlotsBadgeController
+from kaztron.cog.blots.controller import BlotsBadgeController, BlotsConfig
 from kaztron.driver import database
 from kaztron.driver.pagination import Pagination
 from kaztron.kazcog import ready_only
@@ -41,13 +41,15 @@ class BadgeManager(KazCog):
             - report
             - load
     """
+    cog_config: BlotsConfig
+
     ITEMS_PER_PAGE = 8
     EMBED_COLOUR = solarized.green
 
-    badge_channel_id = KazCog.config.get('blots', 'badge_channel')
+    badge_channel_id = KazCog.config.blots.badge_channel
 
     def __init__(self, bot):
-        super().__init__(bot)
+        super().__init__(bot, 'blots', BlotsConfig)
         self.channel = None  # type: discord.Channel
         self.c = None  # type: BlotsBadgeController
 

--- a/kaztron/cog/blots/checkin.py
+++ b/kaztron/cog/blots/checkin.py
@@ -88,13 +88,13 @@ class CheckInManager(KazCog):
     async def announce_start(self):
         logger.info("Announcing start of check-in window")
         await self.bot.send_message(self.check_in_channel,
-            "\n" + ("^" * 32) + "\n**Check-ins for this week are now OPEN!**")
+            "~\n" + ("^" * 32) + "\n**Check-ins for this week are now OPEN!**")
 
     @task(is_unique=True)
     async def announce_end(self):
         logger.info("Announcing end of check-in window")
         await self.bot.send_message(self.check_in_channel,
-            "\n**Check-ins for this week are now CLOSED!**\n" + ("$" * 32))
+            "~\n**Check-ins for this week are now CLOSED!**\n" + ("=" * 32))
 
     async def send_check_in_list(self,
                                dest: discord.Channel,

--- a/kaztron/cog/blots/checkin.py
+++ b/kaztron/cog/blots/checkin.py
@@ -30,6 +30,10 @@ class CheckInManager(KazCog):
     description: |
         This module allows {{name}} to manage user check-ins for Inkblood's BLOTS programme, and
         provides tools to help moderators oversee this programme.
+
+        Check-ins are **only** allowed from {{checkin_window_start}} to {{checkin_window_end}},
+        unless you are a mod or a member of the following roles: {{checkin_anytime_roles}}. The
+        start and end of the checkin window are announced in the channel.
     contents:
         - checkin:
             - type
@@ -61,6 +65,21 @@ class CheckInManager(KazCog):
         self.checkin_anytime_roles = []
         self.check_in_channel = None
         self.announce_tasks = []
+
+    def export_kazhelp_vars(self):
+        import calendar
+        window = self.c.get_check_in_window(datetime.utcnow())
+        return {
+            'checkin_window_start': "{} {}".format(
+                calendar.day_name[window[0].weekday()],
+                self.c.checkin_time.strftime('%H:%M') + ' UTC'
+            ),
+            'checkin_window_end': "{} {}".format(
+                calendar.day_name[window[1].weekday()],
+                self.c.checkin_time.strftime('%H:%M') + ' UTC'
+            ),
+            'checkin_anytime_roles': ', '.join(r.name for r in self.checkin_anytime_roles)
+        }
 
     async def on_ready(self):
         await super().on_ready()
@@ -135,6 +154,10 @@ class CheckInManager(KazCog):
             If your project type is "words", enter your word_count in words (total). If your project
             type is "visual" or "script", enter your total number of pages instead. See also
             {{!checkin type}}.
+
+            Check-ins are **only** allowed from {{checkin_window_start}} to {{checkin_window_end}},
+            unless you are a mod or a member of the following roles: {{checkin_anytime_roles}}. The
+            start and end of the checkin window are announced in the channel.
         parameters:
             - name: word_count
               type: number

--- a/kaztron/cog/blots/controller.py
+++ b/kaztron/cog/blots/controller.py
@@ -120,6 +120,9 @@ class CheckInController(BlotsController):
         """
         Get the start and end times for a check-in week that includes the passed date.
         """
+        if not included_date:
+            included_date = datetime.utcnow()
+
         end_date = get_weekday(included_date, self.checkin_weekdays[1], future=True).date()
         start_date = end_date - timedelta(days=7)
 
@@ -137,6 +140,9 @@ class CheckInController(BlotsController):
         Get the start and end times for the current or future check-in window relative to the
         passed date.
         """
+        if not included_date:
+            included_date = datetime.utcnow()
+
         end_date = get_weekday(included_date, self.checkin_weekdays[1], future=True).date()
         start_date = get_weekday(included_date, self.checkin_weekdays[0], future=True).date()
 
@@ -145,6 +151,10 @@ class CheckInController(BlotsController):
 
         end_dt = datetime.combine(end_date, self.checkin_time)
         start_dt = datetime.combine(start_date, self.checkin_time)
+
+        if included_date > end_dt:  # for the day-of, check if the time has already passed
+            end_dt += timedelta(days=7)
+            start_dt += timedelta(days=7)
 
         return start_dt, end_dt
 

--- a/kaztron/cog/modnotes/modnotes.py
+++ b/kaztron/cog/modnotes/modnotes.py
@@ -580,7 +580,7 @@ class ModNotes(KazCog):
               optional: true
               default: 1
               type: number
-              description: "The page number to show, if there are more than 1 page of notes."
+              description: "The page number to show, if there are more than 1 page of results."
         examples:
             - command: ".notes finduser Indium"
               description: 'This would match, for example, a user called "IndiumPhosphide".'

--- a/kaztron/cog/modnotes/modnotes.py
+++ b/kaztron/cog/modnotes/modnotes.py
@@ -11,6 +11,7 @@ from kaztron import KazCog
 from kaztron import theme
 from kaztron.driver import database as db
 from kaztron.driver.pagination import Pagination
+from kaztron.utils.converter import NaturalInteger
 from kaztron.utils.datetime import parse as dt_parse
 from kaztron.utils.checks import mod_only, mod_channels, admin_only, admin_channels
 from kaztron.utils.discord import Limits, user_mention, get_command_str, get_help_str, \
@@ -418,7 +419,7 @@ class ModNotes(KazCog):
     @notes.command(pass_context=True, ignore_extra=False, aliases=['x', 'expire'])
     @mod_only()
     @mod_channels(delete_on_fail=True)
-    async def expires(self, ctx, note_id: int, *, timespec: str="now"):
+    async def expires(self, ctx, note_id: NaturalInteger, *, timespec: str="now"):
         """!kazhelp
         description: Change the expiration time of an existing note.
         parameters:
@@ -437,6 +438,8 @@ class ModNotes(KazCog):
             - command: .notes expires 138 2018-01-24
               description: Change the expiration time of note #138 to 24 January 2018.
         """
+        note_id: int
+
         expires = dt_parse(timespec, future=True)
         if expires is None:  # dateparser failed to parse
             raise commands.BadArgument("Invalid timespec: '{}'".format(timespec))
@@ -454,7 +457,7 @@ class ModNotes(KazCog):
     @notes.command(pass_context=True, ignore_extra=False, aliases=['r', 'remove'])
     @mod_only()
     @mod_channels(delete_on_fail=True)
-    async def rem(self, ctx, note_id: int):
+    async def rem(self, ctx, note_id: NaturalInteger):
         """!kazhelp
         description: Remove an existing note.
         details: To prevent accidental data deletion, the removed note can be viewed and restored by
@@ -467,6 +470,8 @@ class ModNotes(KazCog):
             - command: .notes rem 122
               description: Remove note number 122.
         """
+        note_id: int
+
         try:
             record = c.mark_removed_record(note_id)
         except db.orm_exc.NoResultFound:
@@ -512,7 +517,7 @@ class ModNotes(KazCog):
     @notes.command(pass_context=True, ignore_extra=False)
     @admin_only()
     @mod_channels(delete_on_fail=True)
-    async def restore(self, ctx, note_id: int):
+    async def restore(self, ctx, note_id: NaturalInteger):
         """!kazhelp
         description: Restore a removed note.
         parameters:
@@ -520,6 +525,8 @@ class ModNotes(KazCog):
               type: number
               description: The ID of the note to remove. See {{!notes}}.
         """
+        note_id: int
+
         try:
             record = c.mark_removed_record(note_id, removed=False)
         except db.orm_exc.NoResultFound:
@@ -531,7 +538,7 @@ class ModNotes(KazCog):
     @notes.command(pass_context=True, ignore_extra=False)
     @admin_only()
     @mod_channels(delete_on_fail=True)
-    async def purge(self, ctx, note_id: int):
+    async def purge(self, ctx, note_id: NaturalInteger):
         """!kazhelp
         description: |
             Permanently destroy a removed now.
@@ -543,6 +550,8 @@ class ModNotes(KazCog):
               type: number
               description: The ID of the note to remove. See {{!notes}}.
         """
+        note_id: int
+
         try:
             record = c.get_record(note_id, removed=True)
             await self.show_record(ctx.message.channel, record=record, title='Purging...')

--- a/kaztron/cog/modtools.py
+++ b/kaztron/cog/modtools.py
@@ -389,7 +389,7 @@ class ModTools(KazCog):
             auto_truncate=True
         )
         es.add_field_no_break(name="Sender", value=ctx.message.author.mention, inline=True)
-        es.add_field(name="Report Message", value=text)
+        es.add_field(name="Report Message", value=text, inline=False)
         try:
             notif_role = get_named_role(self.server, self.cog_config.notif_role)
             notif_role_mention = notif_role.mention

--- a/kaztron/cog/projects/projects.py
+++ b/kaztron/cog/projects/projects.py
@@ -853,7 +853,7 @@ class ProjectsManager(KazCog):
 
         self.cog_state.wizards = self.wizard_manager
 
-    @project.group(pass_context=True, ignore_extra=False, invoke_without_command=True)
+    @project.group(pass_context=True, ignore_extra=True, invoke_without_command=True)
     @mod_only()
     async def admin(self, ctx: commands.Context):
         """!kazhelp
@@ -861,9 +861,17 @@ class ProjectsManager(KazCog):
         """
         await self.bot.say("{}".format(get_group_help(ctx)))
 
-    @admin.group(name='genre', pass_context=True, ignore_extra=False, invoke_without_command=True)
+    @admin.group(name='genre', pass_context=True, ignore_extra=True, invoke_without_command=True)
     @mod_only()
     async def admin_genre(self, ctx: commands.Context):
+        """!kazhelp
+        description: Command group for genre management.
+        """
+        await self.bot.say("{}".format(get_group_help(ctx)))
+
+    @admin_genre.command(name='list', pass_context=True, ignore_extra=False)
+    @mod_only()
+    async def admin_genre_list(self, ctx: commands.Context):
         """!kazhelp
         description: List all genres.
         """
@@ -989,9 +997,17 @@ class ProjectsManager(KazCog):
         await self.bot.say("Genre deleted: {}".format(name))
         await self.send_output("[Projects] Genre deleted: {}".format(name))
 
-    @admin.group(name='type', pass_context=True, ignore_extra=False, invoke_without_command=True)
+    @admin.group(name='type', pass_context=True, ignore_extra=True, invoke_without_command=True)
     @mod_only()
     async def admin_type(self, ctx: commands.Context):
+        """!kazhelp
+        description: Command group for project type management.
+        """
+        await self.bot.say("{}".format(get_group_help(ctx)))
+
+    @admin_type.command(name='list', pass_context=True, ignore_extra=False)
+    @mod_only()
+    async def admin_type_list(self, ctx: commands.Context):
         """!kazhelp
         description: List all project types.
         """

--- a/kaztron/cog/projects/projects.py
+++ b/kaztron/cog/projects/projects.py
@@ -106,13 +106,14 @@ class ProjectsManager(KazCog):
             - aboutme
             - cancel
             - delete
-            - title
-            - genre
-            - subgenre
-            - type
-            - pitch
-            - url
-            - description
+            - set:
+                - title
+                - genre
+                - subgenre
+                - type
+                - pitch
+                - url
+                - description
             - admin:
                 - genre:
                     - add
@@ -208,7 +209,7 @@ class ProjectsManager(KazCog):
                     'pass_context': True,
                     'ignore_extra': False
                 }
-                cmd = self.project.command(**command_params)(setter)
+                cmd = self.set.command(**command_params)(setter)
                 cmd.instance = self
                 self.project_setters[attr_name] = cmd
             except discord.ClientException as e:
@@ -459,8 +460,7 @@ class ProjectsManager(KazCog):
             Select a project to mark as your 'active' project.
 
             This project will be shown by default when someone looks you up. This is also the
-            project that will be modified by project-editing commands like {{!project wizard}},
-            {{!project title}}, etc.
+            project that will be modified by the {{!project set}} series of commands.
         parameters:
             - name: name
               type: string
@@ -618,8 +618,7 @@ class ProjectsManager(KazCog):
             project command will automatically be cancelled.
 
             TIP: You can specify more information about your project, like a URL and extended
-            description, using {{!project title}}, {{!project genre}}, {{!project subgenre}},
-            {{!project type}}, {{!project pitch}}, {{!project url}}, {{!project description}}.
+            description, using the {{!project set}} series of commands.
         examples:
             - command: .project new
         """
@@ -652,8 +651,7 @@ class ProjectsManager(KazCog):
             project command will automatically be cancelled.
 
             TIP: You can specify more information about your project, like a URL and extended
-            description, using ({{!project title}}, {{!project genre}}, {{!project subgenre}},
-            {{!project type}}, {{!project pitch}}, {{!project url}}, {{!project description}}).
+            description, using the {{!project set}} series of commands.
         examples:
             - command: .project wizard
         """
@@ -852,6 +850,14 @@ class ProjectsManager(KazCog):
                     await update_user_roles(self.bot, self.server, [project.user])
 
         self.cog_state.wizards = self.wizard_manager
+
+    @project.group(pass_context=True, ignore_extra=True, invoke_without_command=True)
+    async def set(self, ctx: commands.Context):
+        """!kazhelp
+        description: Command group for project set commands. See also {{!project new}} and
+            {{!project edit}}.
+        """
+        await self.bot.say("{}".format(get_group_help(ctx)))
 
     @project.group(pass_context=True, ignore_extra=True, invoke_without_command=True)
     @mod_only()

--- a/kaztron/cog/spotlight.py
+++ b/kaztron/cog/spotlight.py
@@ -11,7 +11,6 @@ from discord.ext import commands
 from datetime import datetime, date, timedelta
 
 from kaztron import KazCog, theme, task
-from kaztron.cog.role_man import RoleManager
 from kaztron.driver import gsheets
 from kaztron.utils.checks import mod_only, mod_or_has_role, in_channels_cfg
 from kaztron.utils.converter import NaturalDateConverter
@@ -516,37 +515,31 @@ class Spotlight(KazCog):
 
         self.channel_spotlight = self.validate_channel(self.ch_id_spotlight)
 
-        roleman = self.bot.get_cog("RoleManager")  # type: RoleManager
-        if roleman:
-            try:
-                roleman.add_managed_role(
-                    role_name=self.role_audience_name,
-                    join_name="join",
-                    leave_name="leave",
-                    join_msg=self.msg_join.format(self.feature_name, self.role_host_name),
-                    leave_msg=self.msg_leave.format(self.feature_name, self.role_host_name),
-                    join_err=self.msg_join_err.format(self.feature_name, self.role_host_name),
-                    leave_err=self.msg_leave_err.format(self.feature_name, self.role_host_name),
-                    join_doc=("Join the {0} Audience. This allows you to be pinged by "
-                              "moderators or the Host for news like "
-                              "the start of a new {0} or a newly released schedule.\n\n"
-                              "To leave the Audience, use `.spotlight leave`.")
-                    .format(self.feature_name, self.role_host_name),
-                    leave_doc=("Leave the {0} Audience. See `.help spotlight join` for more "
-                               "information.\n\n"
-                               "To join the {0} Audience, use `.spotlight join`.")
-                    .format(self.feature_name, self.role_host_name),
-                    group=self.spotlight,
-                    cog_instance=self,
-                    ignore_extra=False
-                )
-            except discord.ClientException:
-                logger.warning("`sprint follow` command already defined - "
-                               "this is OK if client reconnected")
-        else:
-            err_msg = "Cannot find RoleManager - is it enabled in config?"
-            logger.error(err_msg)
-            await self.send_output(err_msg)
+        try:
+            self.rolemanager.add_managed_role(
+                role_name=self.role_audience_name,
+                join_name="join",
+                leave_name="leave",
+                join_msg=self.msg_join.format(self.feature_name, self.role_host_name),
+                leave_msg=self.msg_leave.format(self.feature_name, self.role_host_name),
+                join_err=self.msg_join_err.format(self.feature_name, self.role_host_name),
+                leave_err=self.msg_leave_err.format(self.feature_name, self.role_host_name),
+                join_doc=("Join the {0} Audience. This allows you to be pinged by "
+                          "moderators or the Host for news like "
+                          "the start of a new {0} or a newly released schedule.\n\n"
+                          "To leave the Audience, use `.spotlight leave`.")
+                .format(self.feature_name, self.role_host_name),
+                leave_doc=("Leave the {0} Audience. See `.help spotlight join` for more "
+                           "information.\n\n"
+                           "To join the {0} Audience, use `.spotlight join`.")
+                .format(self.feature_name, self.role_host_name),
+                group=self.spotlight,
+                cog_instance=self,
+                ignore_extra=False
+            )
+        except discord.ClientException:
+            logger.warning("`sprint follow` command already defined - "
+                           "this is OK if client reconnected")
 
         for role_name in (self.role_host_name, self.role_audience_name):
             get_named_role(self.server, role_name)  # raise error early if any don't exist

--- a/kaztron/cog/sprint/sprint.py
+++ b/kaztron/cog/sprint/sprint.py
@@ -1138,7 +1138,7 @@ class WritingSprint(KazCog):
     @task_on_sprint_start.error
     @task_on_sprint_warning.error
     @task_on_sprint_end.error
-    async def task_error(self, e: Exception):
+    async def task_error(self, e: Exception, i: TaskInstance):
         logger.exception("Error while executing sprint event task")
         self._save_sprint()
 
@@ -1192,7 +1192,7 @@ class WritingSprint(KazCog):
         self._save_sprint()  # also calls self.state.write() - OK for stats too
 
     @task_on_sprint_results.error
-    async def task_results_error(self, e: Exception):
+    async def task_results_error(self, e: Exception, i: TaskInstance):
         logger.exception("Error while executing sprint event task")
         logger.debug("Resetting sprint state...")
         self.set_state(SprintState.IDLE)
@@ -1200,7 +1200,7 @@ class WritingSprint(KazCog):
         self._save_sprint()
 
     @task_on_sprint_results.cancel
-    async def task_results_cancel(self):
+    async def task_results_cancel(self, i: TaskInstance):
         # should only happen when 'fast-forwarding' the results, after all participants finalise
         # so reverting is enough: no need to resched the results
         logger.info("Sprint results task cancelled: reverting state.")

--- a/kaztron/cog/sprint/sprint.py
+++ b/kaztron/cog/sprint/sprint.py
@@ -1,13 +1,10 @@
 import asyncio
-import logging
 from datetime import timedelta
 from typing import Optional
 
-import discord
 from discord.ext import commands
 
 from kaztron import KazCog, task, TaskInstance
-from kaztron.cog.role_man import RoleManager
 from kaztron.cog.sprint.model import *
 from kaztron.errors import UnauthorizedUserError, ModOnlyError
 from kaztron.theme import solarized
@@ -413,39 +410,30 @@ class WritingSprint(KazCog):
         logger.debug("Validating sprint channel...")
         self.channel = self.validate_channel(self.channel_id)
 
-        roleman = self.bot.get_cog("RoleManager")  # type: RoleManager
-        if roleman:
-            try:
-                roleman.add_managed_role(
-                    role_name=self.role_follow_name,
-                    join_name="follow",
-                    leave_name="unfollow",
-                    join_msg="You will now receive notifications when others start a sprint. You "
-                             "can stop getting notifications by using the `.w unfollow` command.",
-                    leave_msg="You will no longer receive notifications when others start a "
-                              "sprint. "
-                              "You can get notifications again by using the `.w follow` command.",
-                    join_err="Oops! You're already receiving notifications for sprints. "
-                             "Use the `.w unfollow` command to stop getting notifications.",
-                    leave_err="Oops! You're not currently getting notifications for sprints. Use "
-                              "the `.w follow` command if you want to start getting notifications.",
-                    join_doc="Get notified when sprints are happening.",
-                    leave_doc="Stop getting notifications about sprints.\n\n"
-                              "You will still get notifications for sprints you have joined.",
-                    group=self.sprint,
-                    cog_instance=self,
-                    ignore_extra=False
-                )
-            except discord.ClientException:
-                logger.warning("`sprint follow` command already defined - "
-                               "this is OK if client reconnected")
-        else:
-            err_msg = "Cannot find RoleManager - is it enabled in config?"
-            logger.warning(err_msg)
-            try:
-                await self.send_output(err_msg)
-            except discord.HTTPException:
-                logger.exception("Error sending error to output ch")
+        try:
+            self.rolemanager.add_managed_role(
+                role_name=self.role_follow_name,
+                join_name="follow",
+                leave_name="unfollow",
+                join_msg="You will now receive notifications when others start a sprint. You "
+                         "can stop getting notifications by using the `.w unfollow` command.",
+                leave_msg="You will no longer receive notifications when others start a "
+                          "sprint. "
+                          "You can get notifications again by using the `.w follow` command.",
+                join_err="Oops! You're already receiving notifications for sprints. "
+                         "Use the `.w unfollow` command to stop getting notifications.",
+                leave_err="Oops! You're not currently getting notifications for sprints. Use "
+                          "the `.w follow` command if you want to start getting notifications.",
+                join_doc="Get notified when sprints are happening.",
+                leave_doc="Stop getting notifications about sprints.\n\n"
+                          "You will still get notifications for sprints you have joined.",
+                group=self.sprint,
+                cog_instance=self,
+                ignore_extra=False
+            )
+        except discord.ClientException:
+            logger.warning("`sprint follow` command already defined - "
+                           "this is OK if client reconnected")
 
         state = self.get_state()
         if state is not SprintState.IDLE:

--- a/kaztron/cog/sprint/sprint.py
+++ b/kaztron/cog/sprint/sprint.py
@@ -1211,11 +1211,20 @@ class WritingSprint(KazCog):
         self.sprint_data = SprintData()
         self._save_sprint()
 
+    @task_on_sprint_results.cancel
+    async def task_results_cancel(self):
+        # should only happen when 'fast-forwarding' the results, after all participants finalise
+        # so reverting is enough: no need to resched the results
+        logger.info("Sprint results task cancelled: reverting state.")
+        self.state.read()
+        self._load_sprint()
+
     @start.error
     @stop.error
     @join.error
     @leave.error
     @wordcount.error
+    @final.error
     async def sprint_on_error(self, exc, ctx: commands.Context):
         cmd_string = message_log_str(ctx.message)
         state = self.get_state()

--- a/kaztron/cog/test.py
+++ b/kaztron/cog/test.py
@@ -1,3 +1,4 @@
+import discord
 from discord.ext import commands
 
 from kaztron import KazCog
@@ -24,6 +25,36 @@ class TestCog(KazCog):
         self.bot.say(str(len(embeds)))
         for em in embeds:
             await self.bot.say(embed=em)
+
+    @commands.command(pass_context=True)
+    async def message_splitter(self, ctx: commands.Context):
+        lines = []
+        for i in range(50):
+            lines.append('{:d}. The quick brown fox jumped over the lazy dog.'.format(i))
+        full_text = '\n'.join(lines)
+        await self.send_message(ctx.message.channel, full_text, split='line')
+        await self.send_message(ctx.message.channel, full_text, split='word')
+        try:
+            await self.send_message(ctx.message.channel, full_text, auto_split=False)
+        except discord.HTTPException as e:
+            await self.send_message(ctx.message.channel, "Got expected error: " + str(e))
+        else:
+            await self.send_message(ctx.message.channel, "Fail: expected HTTPException")
+
+    @commands.command(pass_context=True)
+    async def mixed_splitter(self, ctx: commands.Context):
+        lines = []
+        for i in range(50):
+            lines.append('{:d}. The quick brown fox jumped over the lazy dog.'.format(i))
+        full_text = '\n'.join(lines)
+
+        es = EmbedSplitter(auto_truncate=True, title="The Title", description="A Short Title")
+        for i in range(10):
+            es.add_field_no_break(name=str(i) + " A", value="A")
+            es.add_field_no_break(name=str(i) + " B", value="B")
+            es.add_field(name=str(i) + " C", value="CCC "*256+'DDD '*32, inline=False)
+
+        await self.send_message(ctx.message.channel, full_text, embed=es, split='line')
 
 
 def setup(bot):

--- a/kaztron/core.py
+++ b/kaztron/core.py
@@ -107,6 +107,7 @@ class CoreCog(kaztron.KazCog):
         try:
             self.bot.kaz_help_parser.variables['output_channel'] = '#' + self.channel_out.name
             self.bot.kaz_help_parser.variables['test_channel'] = '#' + self.channel_test.name
+            self.bot.kaz_help_parser.variables['public_channel'] = '#' + self.channel_public.name
         except AttributeError:
             logger.warning("Help parser not found in bot")
 
@@ -424,7 +425,7 @@ class CoreCog(kaztron.KazCog):
         await self.bot.say(embed=em)
 
     @commands.command(pass_context=True, aliases=['bug', 'issue'])
-    @commands.cooldown(rate=5, per=60)
+    @commands.cooldown(rate=3, per=120)
     async def request(self, ctx, *, content: str):
         """!kazhelp
 

--- a/kaztron/core.py
+++ b/kaztron/core.py
@@ -10,11 +10,11 @@ import kaztron
 from kaztron.config import SectionView
 from kaztron.errors import *
 from kaztron.help_formatter import DiscordHelpFormatter, JekyllHelpFormatter
+from kaztron.rolemanager import RoleManager
 from kaztron.utils.checks import mod_only, mod_channels
 from kaztron.utils.decorators import task_handled_errors
 from kaztron.utils.logging import message_log_str, exc_log_str, tb_log_str, exc_msg_str
-from kaztron.utils.discord import get_command_prefix, get_command_str, get_help_str, get_usage_str, \
-    Limits
+from kaztron.utils.discord import get_command_prefix, get_command_str, get_help_str, get_usage_str
 from kaztron.utils.datetime import format_timestamp
 
 logger = logging.getLogger(__name__)
@@ -494,3 +494,4 @@ class CoreCog(kaztron.KazCog):
 
 def setup(bot):
     bot.add_cog(CoreCog(bot))
+    bot.add_cog(RoleManager(bot))

--- a/kaztron/core.py
+++ b/kaztron/core.py
@@ -244,6 +244,18 @@ class CoreCog(kaztron.KazCog):
             if isinstance(root_exc, KeyboardInterrupt):
                 logger.warning("Interrupted by user (SIGINT)")
                 raise root_exc
+            elif isinstance(root_exc, discord.Forbidden) \
+                    and root_exc.code == DiscordErrorCodes.CANNOT_PM_USER:
+                author: discord.Member = ctx.message.author
+                err_msg = "Can't PM user (FORBIDDEN): {0} {1}".format(
+                    author.nick or author.name, author.id)
+                logger.warning(err_msg)
+                logger.debug(tb_log_str(root_exc))
+                await self.bot.send_message(ctx.message.channel,
+                    ("{} You seem to have PMs from this server disabled or you've blocked me. "
+                     "I need to be able to PM you for this command.").format(author.mention))
+                await self.send_output("[WARNING] " + err_msg, auto_split=False)
+                return  # we don't want the generic "an error occurred!"
             elif isinstance(root_exc, discord.HTTPException):  # API errors
                 err_msg = 'While executing {c}\n\nDiscord API error {e!s}' \
                     .format(c=cmd_string, e=root_exc)

--- a/kaztron/errors.py
+++ b/kaztron/errors.py
@@ -1,6 +1,11 @@
 from discord.ext import commands
 
 
+class DiscordErrorCodes:
+    # https://discordapp.com/developers/docs/topics/opcodes-and-status-codes
+    CANNOT_PM_USER = 50007
+
+
 class BotNotReady(commands.CommandError):
     pass
 

--- a/kaztron/help_formatter.py
+++ b/kaztron/help_formatter.py
@@ -345,6 +345,9 @@ class CoreHelpParser:
             elif check_type is CheckId.C_ADMIN:
                 channels = ['Admin channels']
                 new_brief = '[ADMIN ONLY] ' + data['brief']
+            elif check_type is CheckId.C_PM_ONLY:
+                channels = ['PM only']
+                new_brief = '[PM ONLY]' + data['brief']
 
         if roles:
             data['users'] = ', '.join(roles) + '. ' + data['users']

--- a/kaztron/kazcog.py
+++ b/kaztron/kazcog.py
@@ -72,6 +72,7 @@ class KazCog:
         setattr(self, '_{0.__class__.__name__}__unload'.format(self), self.unload)
         self._ch_out = discord.Object(self._ch_out_id)  # type: discord.Channel
         self._ch_test = discord.Object(self._ch_test_id)  # type: discord.Channel
+        self._ch_pub = discord.Object(self._ch_pub_id)  # type: discord.Channel
 
         # Detect success/error in cog's on_ready w/o boilerplate from the child class
         def on_ready_wrapper(f):
@@ -116,6 +117,7 @@ class KazCog:
         cls.config = cls._config = config
         cls._ch_out_id = cls.config.discord.channel_output
         cls._ch_test_id = cls.config.discord.channel_test
+        cls._ch_pub_id = cls.config.discord.channel_public
         cls.state = cls._state = state
 
     async def on_ready(self):
@@ -124,6 +126,7 @@ class KazCog:
         """
         self._ch_out = self.validate_channel(self._ch_out_id)
         self._ch_test = self.validate_channel(self._ch_test_id)
+        self._ch_pub = self.validate_channel(self._ch_pub_id)
 
     # noinspection PyBroadException
     def unload(self):
@@ -265,6 +268,18 @@ class KazCog:
         await self.send_message(self.channel_out, contents, tts=tts, embed=embed,
             auto_split=auto_split, split=split)
 
+    async def send_public(self, contents, *,
+                          tts=False, embed: Union[discord.Embed, EmbedSplitter]=None,
+                          auto_split=True, split='word'):
+        """
+        Send a message to the bot public output channel.
+
+        Convenience function equivalent to ``self.send_message(self.channel_public, ...)``. See also
+        :meth:`.send_message`.
+        """
+        await self.send_message(self.channel_public, contents, tts=tts, embed=embed,
+            auto_split=auto_split, split=split)
+
     @property
     def core(self):
         # cached since we need this when handling disconnect, after cog potentially unloaded...
@@ -300,6 +315,14 @@ class KazCog:
         :meth:`discord.Client.send_message` and similar.
         """
         return self._ch_out
+
+    @property
+    def channel_public(self) -> discord.Channel:
+        """
+        Configured public output channel. Before on_ready, returns a discord Object only usable in
+        :meth:`discord.Client.send_message` and similar.
+        """
+        return self._ch_pub
 
     @property
     def channel_test(self) -> discord.Channel:

--- a/kaztron/kazcog.py
+++ b/kaztron/kazcog.py
@@ -1,13 +1,16 @@
 import functools
 import logging
 from asyncio import iscoroutinefunction
-from typing import Type, Dict
+from typing import Type, Dict, Union
 
 import discord
 from discord.ext import commands
 
+from kaztron.utils.embeds import EmbedSplitter
 from kaztron.config import KaztronConfig, SectionView
 from kaztron.errors import BotNotReady
+from kaztron.utils.discord import Limits
+from kaztron.utils.strings import natural_split, split_chunks_on
 
 logger = logging.getLogger(__name__)
 
@@ -192,13 +195,75 @@ class KazCog:
             raise ValueError("Channel {} not found".format(id_))
         return channel
 
-    async def send_output(self, *args, **kwargs):
+    async def send_message(self, destination, contents, *, tts=False,
+                           embed: Union[discord.Embed, EmbedSplitter]=None,
+                           auto_split=True, split='word'):
+        """
+        Send a message. This method wraps the :meth:`discord.Client.send_message` method and adds
+        automatic message splitting if a message is too long for one line.
+
+        No parsing of Markdown is done for message splitting; this behaviour may break intended
+        formatting. For messages which may contain formatting, it is suggested you parse and split
+        the message instead of relying on auto-splitting.
+
+        See also :meth:`kaztron.utils.split_chunks_on` and :meth:`kaztron.utils.natural_split` for
+        manual control of splitting behaviour. See also :meth:`kaztron.utils.split_code_chunks_on`
+        for splitting Markdown code blocks manually.
+
+        See also :cls:`kaztron.utils.embeds.EmbedSplitter` for similar functionality in splitting
+        embeds.
+
+        :param destination: he location to send the message (Channel, PrivateChannel, User, etc.)
+        :param contents: The content of the message to send. If this is missing, then the ``embed``
+            parameter must be present.
+        :param tts: Indicates if the message should be sent using text-to-speech.
+        :param embed: The rich embed for the content. Also accepts EmbedSplitter instances, for
+            automatic splitting - in this case, the EmbedSplitter will be finalized by this method.
+        :param auto_split: Whether to auto-split messages that exceed the maximum message length.
+        :param split: What to split on: 'word' or 'line'. 'Line' should only be used for messages
+            known to contain many line breaks, as otherwise auto-splitting is likely to fail.
+        """
+
+        # prepare text contents
+        if not contents or not auto_split:
+            content_chunks = (contents,)
+        else:
+            if split == 'word':
+                content_chunks = natural_split(contents, Limits.MESSAGE)
+            elif split == 'line':
+                content_chunks = split_chunks_on(contents, Limits.MESSAGE, split_char='\n')
+            else:
+                raise ValueError('`split` argument must be \'word\' or \'line\'')
+
+        # prepare embed
+        try:
+            embed_list = embed.finalize()
+        except AttributeError:
+            embed_list = (embed,)
+
+        # strategy: output all text chunks before starting to output embed chunks
+        # so the last text chunk will have the first embed chunk attached
+        # this is because non-split messages usually have the embed appear after the msg -
+        # should be fairly rare for both msg and embed to be split
+        for content_chunk in content_chunks[:-1]:
+            await self.bot.send_message(destination, content_chunk, tts=tts)
+
+        await self.bot.send_message(destination, content_chunks[-1], tts=tts, embed=embed_list[0])
+
+        for embed_chunk in embed_list[1:]:
+            await self.bot.send_message(destination, tts=tts, embed=embed_chunk)
+
+    async def send_output(self, contents, *,
+                          tts=False, embed: Union[discord.Embed, EmbedSplitter]=None,
+                          auto_split=True, split='word'):
         """
         Send a message to the bot output channel.
 
-        Convenience function equivalent to ``self.bot.send_message(self.channel_out, ...).
+        Convenience function equivalent to ``self.send_message(self.channel_out, ...)``. See also
+        :meth:`.send_message`.
         """
-        await self.bot.send_message(self.channel_out, *args, **kwargs)
+        await self.send_message(self.channel_out, contents, tts=tts, embed=embed,
+            auto_split=auto_split, split=split)
 
     @property
     def core(self):

--- a/kaztron/kazcog.py
+++ b/kaztron/kazcog.py
@@ -50,6 +50,7 @@ class KazCog:
     _custom_states = []
 
     _core_cache = None
+    _roleman_cache = None
 
     _ch_out_id = None
     _ch_test_id = None
@@ -202,10 +203,17 @@ class KazCog:
     @property
     def core(self):
         # cached since we need this when handling disconnect, after cog potentially unloaded...
-        from kaztron.cog.core import CoreCog
+        from kaztron.core import CoreCog
         if not self._core_cache:
             self._core_cache = self.bot.get_cog('CoreCog')
         return self._core_cache  # type: CoreCog
+
+    @property
+    def rolemanager(self):
+        from kaztron.rolemanager import RoleManager
+        if not self._roleman_cache:
+            self._roleman_cache = self.bot.get_cog('RoleManager')
+        return self._roleman_cache  # type: RoleManager
 
     @property
     def is_ready(self):

--- a/kaztron/rolemanager.py
+++ b/kaztron/rolemanager.py
@@ -148,7 +148,7 @@ class RoleManager(KazCog):
 
         ```python
         try:
-            roleman.add_managed_role(
+            self.rolemanager.add_managed_role(
                 role_name="Sprinters",
                 join_name="follow",
                 leave_name="unfollow",
@@ -178,8 +178,8 @@ class RoleManager(KazCog):
         * `role_name`: The role to manage.
         * `join_name`: The join command name. If `group` is passed, this command is a subcommand of
             that group.
-        * `leave_name`: The leave command name. If `group` is passed, this command is a subcommand of
-            that group.
+        * `leave_name`: The leave command name. If `group` is passed, this command is a subcommand
+            of that group.
         * `join_aliases`: Optional. A sequence of join command aliases.
         * `leave_aliases`: Optional. An sequence of leave command aliases.
         * `join_msg`: Message to send when the user successfully joins the role.
@@ -206,7 +206,8 @@ class RoleManager(KazCog):
         of the structure, and refer to section above for documentation on the parameters.
     """
     def __init__(self, bot):
-        super().__init__(bot)
+        super().__init__(bot, 'rolemanager')
+        self.cog_config.set_defaults(user_roles={}, mod_roles={})
         self.managed_roles = {}
 
     async def on_ready(self):
@@ -291,11 +292,11 @@ class RoleManager(KazCog):
 
     def setup_all_config_roles(self):
         logger.info("Setting up managed roles from configuration")
-        user_role_map = self.config.get('role_man', 'user_roles', {})
+        user_role_map = self.cog_config.user_roles
         for name, args in user_role_map.items():
             self.setup_config_role(name, args)
 
-        mod_role_map = self.config.get('role_man', 'mod_roles', {})
+        mod_role_map = self.cog_config.mod_roles
         for name, args in mod_role_map.items():
             self.setup_config_role(name, args, [mod_only()])
 
@@ -339,7 +340,3 @@ class RoleManager(KazCog):
         current_group = parent.group(
             name=name, invoke_without_command=True, pass_context=True)(anonymous_group)
         current_group.instance = self
-
-
-def setup(bot):
-    bot.add_cog(RoleManager(bot))

--- a/kaztron/runner.py
+++ b/kaztron/runner.py
@@ -116,9 +116,11 @@ def run(loop: asyncio.AbstractEventLoop):
     client.scheduler = Scheduler(client)
     client.kaz_help_parser = kaz_help_parser
 
+    # Load core extension (core + rolemanager)
+    client.load_extension("kaztron.core")
+
     # Load extensions
     startup_extensions = config.get("core", "extensions")
-    client.load_extension("kaztron.cog.core")
     for extension in startup_extensions:
         logger.debug("Loading extension: {}".format(extension))
         # noinspection PyBroadException

--- a/kaztron/utils/checks.py
+++ b/kaztron/utils/checks.py
@@ -25,6 +25,7 @@ class CheckId(Enum):
     C_LIST = 10
     C_MOD = 11
     C_ADMIN = 12
+    C_PM_ONLY = 13
 
 
 def has_role(role_names: Union[str, Iterable[str]]):
@@ -163,3 +164,20 @@ def admin_channels(delete_on_fail=False):
     """
     return in_channels_cfg('discord', 'admin_channels', allow_pm=True,
         delete_on_fail=delete_on_fail, check_id=CheckId.C_ADMIN)
+
+
+def pm_only(delete_on_fail=False):
+    """
+    Command check decorator. Only allow this command in PMs.
+    """
+    def predicate(ctx: commands.Context):
+        if ctx.message.channel.is_private:
+            return True
+        else:
+            if not delete_on_fail:
+                raise UnauthorizedChannelError("Command only allowed in PMs.", ctx)
+            else:
+                raise DeleteMessage(UnauthorizedChannelError("Command only allowed in PMs.", ctx))
+    predicate.kaz_check_id = CheckId.C_PM_ONLY
+    predicate.kaz_check_data = tuple()
+    return commands.check(predicate)

--- a/kaztron/utils/converter.py
+++ b/kaztron/utils/converter.py
@@ -50,8 +50,11 @@ class BooleanConverter(commands.Converter):
 
 class NaturalInteger(commands.Converter):
     """
-    Integer converter that is tolerant of various natural number input conventions (e.g. commas as
-    digit grouping separators).
+    Integer converter that is tolerant of various natural number input conventions:
+
+    * Commas or periods as digit grouping separators
+    * Period or comma as decimal point (identified as an error -> not an integer)
+    * '#' prepended to an integer, for ordinals, IDs and list items.
 
     This converter is tolerant of three common locale conventions, along with normal Python integer
     literals, and attempts a best guess at conversion:
@@ -79,7 +82,7 @@ class NaturalInteger(commands.Converter):
         as floating-point.
     """
     def convert(self):
-        n_str = self.argument.rstrip(',.')
+        n_str = self.argument.rstrip(',.').strip('#')
         try:
             return int(n_str)
         except ValueError:

--- a/kaztron/utils/embeds.py
+++ b/kaztron/utils/embeds.py
@@ -195,6 +195,7 @@ class EmbedSplitter:
         self._flush_field_cache()
         if not self.repeat_footer:
             footer = self.template.footer
+            self.cur_embed.timestamp = self.template.timestamp
             self.cur_embed.set_footer(text=footer.text, icon_url=footer.icon_url)
         self.cur_embed = None
         embeds = list(self._embeds)


### PR DESCRIPTION
# Changelog

## Core
* KazCog now includes `send_message`, `say` and `send_output` with automatic message splitting capabilities for long messages, as well as support for `EmbedSplitter` class instances for automatically splitting embeds. Note that these are called inside a cog via `self.send_message(...)` etc., as opposed to `self.bot.send_message(...)` etc. #114
* RoleManager (formerly role_man) is now a core component. It is loaded by default and need no longer be specified in the extensions list in `config.json`. #130
* Commands that PM users will now send an appropriate error message in-channel if PMs are disabled. (Non-command PMs, e.g. reminders, must handle this situation themselves.) #35
* Scheduler error/cancel handlers now take a required TaskInstance argument.

## Inkblood BLOTS
* `.checkin report`: for a given checkin week, checked-in-users are explicitly ordered by name, and non-checked-in users are listed by the date of their last known checkin. #185
* checkins are now only allowed during a specific time frame (via config, with a list of roles that are excepted from this via config). Time frame start/end is announced in the checkin channel. #133`

## Modnotes
* Support `#dddd` notation for note IDs #186

## Modtools
* Add `.report` for confidential user reports to the mod team

## Projects
* Command groups within `.projects admin` will now output sub-command help even if parameters are specified (previously gave a too-many-arguments error).
* `.projects admin genre` and `.projects admin type` are now purely command groups. To list all genres or types, use the subcommand `.projects admin genre list` or `.projects admin type list`.
## Sprints
* Reliability improvements: handle cancellation of the results/finalisation task, if interrupted. This may fix a race condition in which the `.w final` call occurs near or soon after the end of the finalise period. (Possibly related to #86)

## Reminders
* Internal clean-up - update to use new-style config, clean up tasks.
* Notify user if their PMs are disabled, at reminder time. #35

## Userstats
* Various speed optimisations. Report generation is now ~90% faster.
* `.report` renamed to `.userstats report` due to modtools conflict