### PR TITLE
v2.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ config-*.json
 state.json
 state-*.json
 client_secret.json
+test.json
 *.sublime-*
 *.sqlite
 *.orig

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -21,6 +21,13 @@
         </value>
       </option>
     </inspection_tool>
+    <inspection_tool class="PyPep8Inspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="E128" />
+        </list>
+      </option>
+    </inspection_tool>
     <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoredIdentifiers">
         <list>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -5,10 +5,9 @@
     <inspection_tool class="PyCompatibilityInspection" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ourVersions">
         <value>
-          <list size="3">
-            <item index="0" class="java.lang.String" itemvalue="3.5" />
-            <item index="1" class="java.lang.String" itemvalue="3.6" />
-            <item index="2" class="java.lang.String" itemvalue="3.7" />
+          <list size="2">
+            <item index="0" class="java.lang.String" itemvalue="3.6" />
+            <item index="1" class="java.lang.String" itemvalue="3.7" />
           </list>
         </value>
       </option>

--- a/config.example.json
+++ b/config.example.json
@@ -113,12 +113,16 @@
     "channel_warning": "channel ID for MODERATOR filter warning/delete notifications"
   },
   "modnotes": {
-    "channel_log": "channel ID - for channel to log all new records to (read-only ideally?)"
+    "channel_log": "channel ID - for channel to log all new records to (read-only ideally?)",
+    "channel_mod": "channel ID for notifications to mods (used by extensions)",
+    "ban_check_interval": 3600,
+    "ban_role": "role name for banned members",
+    "ban_temp_enforce": false,
+    "ban_perma_enforce": false,
+    "ban_temp_expires": "in 7 days"
   },
   "modtools": {
-    "tempban_role": "Role Name Here",
     "notif_role": "Name of role used to send notifications to all mods",
-    "channel_mod": "ID of channel for mod notifications (like timed unbans)",
     "distinguish_map": {
       "mod-role1": "distinguish-role1",
       "mod-role2": "distinguish-role2"
@@ -181,6 +185,9 @@
     "duration_max": 3600,
     "finalize_time": 300,
     "report_time": "time at which reports are generated weekly, default 17:00"
+  },
+  "sticky": {
+    "delay": 300
   },
   "userstats": {
     "ignore_users": ["user ID 1", "user ID 2", "etc"],

--- a/config.example.json
+++ b/config.example.json
@@ -12,7 +12,7 @@
   },
   "core": {
     "name": "KazTronExampleBot",
-    "extensions": ["welcome", "wordfilter", "dice", "modtools", "spotlight", "modnotes", "reminder", "sprint", "quotedb", "voicelog"],
+    "extensions": ["dice", "fuck", "modnotes", "modnotes.bantools", "modnotes.jointools","modtools", "quotedb", "reminder", "resource_channel", "spotlight", "sprint", "sticky", "test", "userstats", "voicelog", "welcome", "wordfilter"],
     "channel_request": "channel ID for requests",
     "info_links": {
       "link name 1": "http://potato.example/url/to/something",

--- a/config.example.json
+++ b/config.example.json
@@ -158,7 +158,8 @@
     "allow_strings": ["https://", "http://"],
     "allow_re_strings": [],
     "deny_strings": [],
-    "deny_re_strings": []
+    "deny_re_strings": [],
+    "allow_uploads": true
   },
   "spotlight": {
     "name": "World Spotlight",

--- a/config.example.json
+++ b/config.example.json
@@ -143,6 +143,11 @@
     "datetime_format": "one of: seconds, datetime, date",
     "show_channel": false
   },
+  "reminders": {
+    "max_per_user": 10,
+    "renew_limit": 25,
+    "renew_interval_min": 600
+  },
   "spotlight": {
     "name": "World Spotlight",
     "channel": "Channel ID",

--- a/config.example.json
+++ b/config.example.json
@@ -12,7 +12,7 @@
   },
   "core": {
     "name": "KazTronExampleBot",
-    "extensions": ["dice", "fuck", "modnotes", "modnotes.bantools", "modnotes.jointools","modtools", "quotedb", "reminder", "resource_channel", "spotlight", "sprint", "sticky", "test", "userstats", "voicelog", "welcome", "wordfilter"],
+    "extensions": ["dice", "discordtools", "fuck", "modnotes", "modnotes.bantools", "modnotes.jointools","modtools", "quotedb", "reminder", "resource_channel", "spotlight", "sprint", "sticky", "test", "userstats", "voicelog", "welcome", "wordfilter"],
     "channel_request": "channel ID for requests",
     "info_links": {
       "link name 1": "http://potato.example/url/to/something",

--- a/kaztron/__init__.py
+++ b/kaztron/__init__.py
@@ -3,8 +3,8 @@ from collections import OrderedDict
 from .kazcog import KazCog
 from .scheduler import Scheduler, TaskInstance, task
 
-__release__ = "2.3"  # release stream, usually major.minor only
-__version__ = "2.3.4"
+__release__ = "2.4"  # release stream, usually major.minor only
+__version__ = "2.4.0"
 
 bot_info = {
     "version": __version__,

--- a/kaztron/cog/blots/badges.py
+++ b/kaztron/cog/blots/badges.py
@@ -72,7 +72,7 @@ class BadgeManager(KazCog):
     async def on_ready(self):
         await super().on_ready()
         channel_id = self.config.get('blots', 'badge_channel')
-        self.channel = self.validate_channel(channel_id)
+        self.channel = self.get_channel(channel_id)
         self.c = BlotsBadgeController(self.server, self.config)
 
     def export_kazhelp_vars(self):

--- a/kaztron/cog/blots/checkin.py
+++ b/kaztron/cog/blots/checkin.py
@@ -85,7 +85,7 @@ class CheckInManager(KazCog):
 
     async def on_ready(self):
         await super().on_ready()
-        self.check_in_channel = self.validate_channel(self.check_in_channel_id)
+        self.check_in_channel = self.get_channel(self.check_in_channel_id)
         self.checkin_anytime_roles = tuple(get_named_role(self.server, n)
                                            for n in self.cog_config.check_in_window_exempt_roles)
         milestone_map = {}

--- a/kaztron/cog/dice.py
+++ b/kaztron/cog/dice.py
@@ -31,7 +31,7 @@ class Dice(KazCog):
     def __init__(self, bot):
         super().__init__(bot, 'dice', DiceConfig)
         self.cog_config.set_converters('channel_dice',
-            lambda cid: self.validate_channel(cid),
+            lambda cid: self.get_channel(cid),
             lambda _: None)
         self.ch_dice = None
 

--- a/kaztron/cog/discordtools.py
+++ b/kaztron/cog/discordtools.py
@@ -1,0 +1,63 @@
+import logging
+
+from discord.ext import commands
+
+from kaztron import KazCog
+from kaztron.utils.checks import mod_only, mod_channels
+from kaztron.utils.discord import channel_mention
+
+logger = logging.getLogger(__name__)
+
+
+class DiscordTools(KazCog):
+    """!kazhelp
+    category: Commands
+    brief: Various tools to help with Discord.
+    description:
+    contents:
+        - id
+        - rchid
+    """
+
+    def __init__(self, bot):
+        super().__init__(bot)
+
+    @commands.command(pass_context=True, ignore_extra=True, no_pm=False)
+    async def id(self, ctx: commands.Context):
+        """!kazhelp
+
+        description: Gets your own user ID.
+        parameters: []
+        examples:
+            - command: .id
+              description: Gets your own user ID.
+        """
+        await self.send_message(ctx.message.channel, ctx.message.author.mention +
+            " Your ID is: " + ctx.message.author.id)
+
+    @commands.command(pass_context=True, ignore_extra=True, no_pm=False)
+    @mod_only()
+    @mod_channels()
+    async def rchid(self, ctx: commands.Context, *, ids: str):
+        """!kazhelp
+
+        description: Convert channel IDs to channel links.
+        details: "This command is primarily intended for bot operators to help in validating
+            the configuration file."
+        parameters:
+            - name: ids
+              type: str
+              description: "A list of channel IDs. They may be comma- or line-separated and may or
+                may not be quoted, using either double or single quotes."
+        examples:
+            - command: |
+                    .rchid "123456789012345678", "876543210987654321"
+              description: Translates these two IDs into channel names, e.g., #general, #potato.
+        """
+        ids_list = [s.strip().strip(r"'\"[]{}") for s in ids.replace(',', '\n').splitlines()]
+        await self.send_message(ctx.message.channel, ctx.message.author.mention + "\n" +
+            '\n'.join(channel_mention(cid) for cid in ids_list))
+
+
+def setup(bot):
+    bot.add_cog(DiscordTools(bot))

--- a/kaztron/cog/discordtools.py
+++ b/kaztron/cog/discordtools.py
@@ -1,9 +1,11 @@
 import logging
+from datetime import datetime
 
 from discord.ext import commands
 
 from kaztron import KazCog
 from kaztron.utils.checks import mod_only, mod_channels
+from kaztron.utils.datetime import format_datetime
 from kaztron.utils.discord import channel_mention
 
 logger = logging.getLogger(__name__)
@@ -34,6 +36,20 @@ class DiscordTools(KazCog):
         """
         await self.send_message(ctx.message.channel, ctx.message.author.mention +
             " Your ID is: " + ctx.message.author.id)
+
+    @commands.command(pass_context=True, ignore_extra=True, no_pm=False, aliases=['now', 'time'])
+    async def kaztime(self, ctx: commands.Context):
+        """!kazhelp
+
+        description: "Gets the current KazTron Time (UTC, GMT). Can be used to help convert
+            community programme schedules to your timezone."
+        parameters: []
+        examples:
+            - command: .kaztime
+              description: Shows the current time.
+        """
+        await self.send_message(ctx.message.channel, ctx.message.author.mention +
+            "Current KazTime: {} UTC".format(format_datetime(datetime.utcnow(), seconds=True)))
 
     @commands.command(pass_context=True, ignore_extra=True, no_pm=False)
     @mod_only()

--- a/kaztron/cog/discordtools.py
+++ b/kaztron/cog/discordtools.py
@@ -17,6 +17,7 @@ class DiscordTools(KazCog):
     brief: Various tools to help with Discord.
     description:
     contents:
+        - kaztime
         - id
         - rchid
     """

--- a/kaztron/cog/fuck.py
+++ b/kaztron/cog/fuck.py
@@ -1,0 +1,24 @@
+import logging
+import random
+
+import discord
+from discord.ext import commands
+
+from kaztron import KazCog
+
+logger = logging.getLogger(__name__)
+
+
+class FuckCog(KazCog):
+    FUCK_LIST = [
+        "https://tenor.com/view/gomen-naka-naori-kenka-ayamaru-gif-11957657",
+        "https://tenor.com/view/kaede-girl-senpai-panda-gomen-gif-16026628"
+    ]
+
+    @commands.command(pass_context=True)
+    async def fuck(self, ctx: commands.Context):
+        await self.send_message(ctx.message.channel, random.choice(self.FUCK_LIST))
+
+
+def setup(bot):
+    bot.add_cog(FuckCog(bot))

--- a/kaztron/cog/modnotes/__init__.py
+++ b/kaztron/cog/modnotes/__init__.py
@@ -1,4 +1,4 @@
-from .modnotes import ModNotes
+from .modnotes import ModNotes, ModNotesConfig
 from .controller import init_db
 
 

--- a/kaztron/cog/modnotes/bantools.py
+++ b/kaztron/cog/modnotes/bantools.py
@@ -1,0 +1,7 @@
+"""
+File description.
+
+Project: Project Name
+"""
+
+__author__ = 'marcalexc'

--- a/kaztron/cog/modnotes/bantools.py
+++ b/kaztron/cog/modnotes/bantools.py
@@ -1,7 +1,238 @@
-"""
-File description.
+from datetime import timedelta
+import logging
+from typing import List
 
-Project: Project Name
-"""
+import discord
+from discord.ext import commands
 
-__author__ = 'marcalexc'
+from kaztron import KazCog, task
+from kaztron.cog.modnotes.model import RecordType
+from kaztron.cog.modnotes.modnotes import ModNotes
+from kaztron.cog.modnotes import controller, model, ModNotesConfig
+from kaztron.errors import BotCogError
+from kaztron.kazcog import ready_only
+from kaztron.utils.checks import mod_only, mod_channels
+from kaztron.utils.datetime import format_timedelta
+from kaztron.utils.discord import get_named_role
+from kaztron.utils.strings import parse_keyword_args
+
+logger = logging.getLogger(__name__)
+
+
+class BanToolsConfig(ModNotesConfig):
+    """
+    :ivar ban_check_interval: Interval (in seconds) to re-check bans.
+    :ivar ban_role: The name of a role used to tempban (usually mute, deny channel access, etc.)
+        a user.
+    :ivar ban_temp_expires: Default expiration time. Timespec, same as `.notes add`'s `expires`
+        argument.
+    :ivar ban_temp_enforce: If true, periodically enforce active tempbans.
+    :ivar ban_perma_enforce: If true, periodically validate active permabans. If tempban_enforce is
+        also true, then permabans will be enforced with the tempban_role. (This bot will not
+        enforce a Discord server ban - it is designed so as to limit granting the bot higher-risk
+        permissions).
+    """
+    ban_check_interval: timedelta
+    ban_role: discord.Role
+    ban_temp_expires: str
+    ban_temp_enforce: bool
+    ban_perma_enforce: bool
+
+
+class BanTools(KazCog):
+    """!kazhelp
+    category: Moderator
+    brief: Mod notes tools to help enforce and keep track of bans.
+    description: |
+        Various tools for moderators to help enforce and track bans! This cog depends on the
+        {{%ModNotes}} module.
+
+        This module can automatically enforce modnotes of type 'temp' and 'perma', at startup and
+        every {{check_interval}} hence.
+
+        TODO: trigger an enforce on adding a note
+    contents:
+        - ban
+            - enforce
+            - list
+        - tempban
+    """
+    cog_config: BanToolsConfig
+
+    #####
+    # Lifecycle
+    #####
+
+    def __init__(self, bot):
+        super().__init__(bot, 'modnotes', BanToolsConfig)
+        self.cog_config.set_defaults(
+            ban_check_interval=3600,
+            ban_temp_expires='in 7 days',
+            ban_temp_enforce=False,
+            ban_perma_enforce=False
+        )
+        self.cog_config.set_converters('ban_check_interval', lambda s: timedelta(seconds=s), None)
+        self.cog_config.set_converters('ban_role',
+            lambda r: get_named_role(self.server, r), None)
+        self.cog_config.set_converters('channel_mod', self.get_channel, None)
+        self.cog_modnotes: ModNotes = None
+
+    async def on_ready(self):
+        await super().on_ready()
+        self.cog_modnotes = self.get_cog_dependency(ModNotes.__name__)
+        _ = self.cog_config.ban_role  # validate that it is set and exists
+        _ = self.cog_config.channel_mod  # validate that it is set and exists
+
+        # schedule tempban update tick (unless already done i.e. reconnects)
+        if self.cog_config.ban_temp_enforce or self.cog_config.ban_perma_enforce:
+            if self.cog_modnotes and not self.scheduler.get_instances(self.task_update_tempbans):
+                self.scheduler.schedule_task_in(
+                    self.task_update_tempbans, 0, every=self.cog_config.ban_check_interval
+                )
+
+    def export_kazhelp_vars(self):
+        return {
+            'mod_channel': '#' + self.cog_config.channel_mod.name,
+            'check_interval': format_timedelta(self.cog_config.ban_check_interval),
+            'temp_expires': self.cog_config.ban_temp_expires
+        }
+
+    def unload_kazcog(self):
+        self.scheduler.cancel_all(self.task_update_tempbans)
+
+    #####
+    # Core
+    #####
+
+    @staticmethod
+    def _get_tempbanned_members_db(server: discord.Server, include_perma=False) \
+            -> List[model.Record]:
+        if include_perma:
+            types = (RecordType.temp, RecordType.perma)
+        else:
+            types = (RecordType.temp,)
+        records = controller.query_unexpired_records(types=types)
+        members_raw = (server.get_member(record.user.discord_id) for record in records)
+        return [m for m in members_raw if m is not None]
+
+    def _get_tempbanned_members_server(self, server: discord.Server) -> List[discord.Member]:
+        return [m for m in server.members if self.cog_config.ban_role in m.roles]
+
+    async def _update_tempbans(self):
+        """
+        Check and update all current tempbans in modnotes. Unexpired tempbans will be applied and
+        expired tempbans will be removed, when needed.
+        """
+        if not self.cog_config.ban_temp_enforce:
+            return
+
+        logger.info("Checking all tempbans.")
+        try:
+            server = self.cog_config.channel_mod.server  # type: discord.Server
+        except AttributeError:  # get_channel failed
+            logger.error("Can't find mod channel")
+            await self.send_output("**ERROR**: update_tempbans: can't find mod channel")
+            return
+
+        bans_db = self._get_tempbanned_members_db(server)
+        bans_server = self._get_tempbanned_members_server(server)
+
+        # check if any members who need to be banned
+        for member in bans_db:
+            if member not in bans_server:
+                logger.info("Applying tempban role '{role}' to {user!s}...".format(
+                    role=self.cog_config.ban_role.name,
+                    user=member
+                ))
+                await self.bot.add_roles(member, self.cog_config.ban_role)
+                await self.bot.send_message(self.cog_config.channel_mod,
+                    "Tempbanned {.mention}".format(member))
+
+        # check if any members who need to be unbanned
+        for member in bans_server:
+            if member not in bans_db:
+                logger.info("Removing tempban role '{role}' to {user!s}...".format(
+                    role=self.cog_config.ban_role.name,
+                    user=member
+                ))
+                await self.bot.remove_roles(member, self.cog_config.ban_role)
+                await self.bot.send_message(self.cog_config.channel_mod,
+                    "Unbanned {.mention}".format(member))
+
+    #####
+    # Discord
+    #####
+
+    @ready_only
+    async def on_member_join(self, _: discord.Member):
+        await self._update_tempbans()
+
+    @task(is_unique=True)
+    async def task_update_tempbans(self):
+        await self._update_tempbans()
+
+    @commands.command(pass_context=True)
+    @mod_only()
+    @mod_channels()
+    async def tempban(self, ctx: commands.Context, user: str, *, reason: str = ""):
+        """!kazhelp
+
+        description: |
+            Tempban a user.
+
+            This command will immediately tempban (mute) the user, and create a modnote. It will not
+            communicate with the user.
+
+            The user will be unbanned (unmuted) when the tempban expires.
+
+            Note that the ModTools module automatically enforces all tempban modules. See the
+            {{%ModTools}} introduction or `.help ModTools` for more info.
+
+            This command is shorthand for `.notes add <user> temp expires="[expires]" [reason]`.
+        parameters:
+            - name: user
+              type: string
+              description: The user to ban. See {{!notes}} for more information.
+            - name: reason
+              type: string
+              optional: true
+              description: "Complex parameter of the format `[expires=[expires]] [reason]`. `reason`
+                is the reason for the tempban, to be recorded as a modnote (optional but highly
+                recommended)."
+            - name: expires
+              type: datespec
+              optional: true
+              description: "The datespec for the tempban's expiration. Use quotation marks if the
+                datespec has spaces in it. See {{!notes add}} for more information on accepted
+                syntaxes."
+              default: '"{{temp_expires}}"'
+        examples:
+            - command: .tempban @BlitheringIdiot#1234 Was being a blithering idiot.
+              description: Issues a ban of default duration ({{temp_expires}}).
+            - command: .tempban @BlitheringIdiot#1234 expires="in 3 days" Was being a slight
+                blithering idiot only.
+              description: Issues a 3-day ban.
+        """
+        if not self.cog_modnotes:
+            raise BotCogError("ModNotes cog not loaded. This command requires ModNotes to run.")
+
+        # Parse and validate kwargs (we won't use this, just want to validate valid keywords)
+        try:
+            kwargs, rem = parse_keyword_args(self.cog_modnotes.KW_EXPIRE, reason)
+        except ValueError as e:
+            raise commands.BadArgument(e.args[0]) from e
+        else:
+            if not kwargs:
+                reason = 'expires="{}" {}'.format(self.cog_config.ban_temp_expires, reason)
+            if not rem:
+                reason += " No reason specified."
+
+        # Write the note
+        await ctx.invoke(self.cog_modnotes.add, user, 'temp', note_contents=reason)
+
+        # Apply new mutes
+        await self._update_tempbans()
+
+
+def setup(bot):
+    bot.add_cog(BanTools(bot))

--- a/kaztron/cog/modnotes/bantools.py
+++ b/kaztron/cog/modnotes/bantools.py
@@ -51,7 +51,7 @@ class BanTools(KazCog):
         This module can automatically enforce modnotes of type 'temp' and 'perma', at startup and
         every {{check_interval}} hence.
     contents:
-        - tempban
+        - tempban:
             - enforce
     """
     cog_config: BanToolsConfig

--- a/kaztron/cog/modnotes/bantools.py
+++ b/kaztron/cog/modnotes/bantools.py
@@ -10,13 +10,11 @@ from kaztron import KazCog, task
 from kaztron.cog.modnotes.model import RecordType
 from kaztron.cog.modnotes.modnotes import ModNotes
 from kaztron.cog.modnotes import controller, ModNotesConfig
-from kaztron.driver.pagination import Pagination
 from kaztron.errors import BotCogError
 from kaztron.kazcog import ready_only
 from kaztron.utils.checks import mod_only, mod_channels
 from kaztron.utils.datetime import format_timedelta
-from kaztron.utils.discord import get_named_role, get_group_help
-from kaztron.utils.logging import exc_log_str
+from kaztron.utils.discord import get_named_role
 from kaztron.utils.strings import parse_keyword_args
 
 logger = logging.getLogger(__name__)

--- a/kaztron/cog/modnotes/bantools.py
+++ b/kaztron/cog/modnotes/bantools.py
@@ -16,6 +16,7 @@ from kaztron.kazcog import ready_only
 from kaztron.utils.checks import mod_only, mod_channels
 from kaztron.utils.datetime import format_timedelta
 from kaztron.utils.discord import get_named_role, get_group_help
+from kaztron.utils.logging import exc_log_str
 from kaztron.utils.strings import parse_keyword_args
 
 logger = logging.getLogger(__name__)
@@ -298,7 +299,7 @@ class BanTools(KazCog):
         await self._update_tempbans()
         await self._check_permabans()
         await self.send_message(ctx.message.channel, ctx.message.author.mention +
-                                                     " Updated all bans.")
+            " Updated all bans.")
 
 
 def setup(bot):

--- a/kaztron/cog/modnotes/bantools.py
+++ b/kaztron/cog/modnotes/bantools.py
@@ -103,9 +103,7 @@ class BanTools(KazCog):
 
             for cmd in (self.cog_modnotes.add, self.cog_modnotes.expires,
                         self.cog_modnotes.rem, self.cog_modnotes.restore):
-                logger.info(repr(cmd.callback))
                 cmd.callback = wrapper(cmd.callback)
-                logger.info(repr(cmd.callback))
             self.modnotes_patch_applied = True
 
     def export_kazhelp_vars(self):

--- a/kaztron/cog/modnotes/jointools.py
+++ b/kaztron/cog/modnotes/jointools.py
@@ -1,0 +1,100 @@
+from datetime import datetime
+from datetime import timedelta
+import logging
+
+import discord
+from discord.ext import commands
+
+from kaztron import KazCog
+from kaztron.cog.modnotes.model import JoinDirection
+from kaztron.cog.modnotes.modnotes import ModNotes
+from kaztron.cog.modnotes import controller, ModNotesConfig
+from kaztron.kazcog import ready_only
+from kaztron.utils.checks import mod_only, mod_channels
+from kaztron.utils.discord import get_group_help
+
+logger = logging.getLogger(__name__)
+
+
+class JoinTools(KazCog):
+    """!kazhelp
+    category: Moderator
+    brief: Mod notes tools to help keep track of when users join and leave the guild.
+    description: |
+        Mod notes tools to help keep track of when users join and parts the guild. This cog depends
+        on the {{%ModNotes}} module.
+
+        Join/part records are displayed when looking up a user's history using {{!notes}}. They are
+        not logged on Discord otherwise. If join/part logging is desired, use the {{%Welcome}}
+        module.
+    contents:
+        - jointools:
+            - purge
+    """
+    cog_config: ModNotesConfig
+
+    #####
+    # Lifecycle
+    #####
+
+    def __init__(self, bot):
+        super().__init__(bot, 'modnotes', ModNotesConfig)
+        self.cog_config.set_defaults()
+        self.cog_config.set_converters('channel_mod', self.get_channel, None)
+        self.cog_modnotes: ModNotes = None
+
+    async def on_ready(self):
+        await super().on_ready()
+        self.cog_modnotes = self.get_cog_dependency(ModNotes.__name__)  # type: ModNotes
+        _ = self.cog_config.channel_mod  # validate that it is set and exists
+
+    def export_kazhelp_vars(self):
+        return {
+            'mod_channel': '#' + self.cog_config.channel_mod.name
+        }
+
+    #####
+    # Core
+    #####
+
+    #####
+    # Discord
+    #####
+
+    @ready_only
+    async def on_member_join(self, user: discord.Member):
+        db_user = await controller.query_user(self.bot, user.id)
+        controller.insert_join(user=db_user, direction=JoinDirection.join)
+
+    @ready_only
+    async def on_member_remove(self, user: discord.Member):
+        db_user = await controller.query_user(self.bot, user.id)
+        controller.insert_join(user=db_user, direction=JoinDirection.part)
+
+    @commands.group(pass_context=True, invoke_without_command=True, ignore_extra=True)
+    @mod_only()
+    @mod_channels(delete_on_fail=True)
+    async def jointools(self, ctx):
+        """!kazhelp
+        description: |
+            Command group. Utilities for managing the JoinTools functionality.
+        """
+        await self.bot.say(get_group_help(ctx))
+
+    @jointools.command(pass_context=True, aliases=['a'])
+    @mod_only()
+    @mod_channels(delete_on_fail=True)
+    async def purge(self, ctx: commands.Context):
+        """!kazhelp
+        description: |
+            Purges join/part records of users who a) haven't been seen in at least 30 days; b) have
+            no modnotes.
+        """
+        limit_time = datetime.utcnow() - timedelta(days=30)
+        purge_list = controller.purge_joins(before=limit_time)
+        await self.send_message(ctx.message.channel, ctx.message.author.mention +
+         " Purged {} records".format(len(purge_list)))
+
+
+def setup(bot):
+    bot.add_cog(JoinTools(bot))

--- a/kaztron/cog/modnotes/modnotes.py
+++ b/kaztron/cog/modnotes/modnotes.py
@@ -48,12 +48,12 @@ class ModNotes(KazCog):
         community users.
     contents:
         - notes:
-            - finduser
             - add
             - expires
             - rem
             - watches
             - temps
+            - permas
             - name
             - alias
             - group:
@@ -62,6 +62,7 @@ class ModNotes(KazCog):
             - removed
             - restore
             - purge
+            - finduser
     """
     NOTES_PAGE_SIZE = 10
     USEARCH_PAGE_SIZE = 20
@@ -282,6 +283,33 @@ class ModNotes(KazCog):
         await self.show_record_page(
             ctx.message.channel,
             records=records_pages, user=None, title='Active Temporary Bans (Mutes)'
+        )
+
+    @notes.command(aliases=['perma'], pass_context=True, ignore_extra=False)
+    @mod_only()
+    @mod_channels()
+    async def permas(self, ctx, page: int=None):
+        """!kazhelp
+        description: Show all permanent bans currently in effect (i.e. non-expired `perma` records).
+        details: |
+            10 notes are shown per page. This is partly due to Discord message length limits, and
+            partly to avoid too large a data dump in a single request.
+        parameters:
+            - name: page
+              optional: true
+              default: last page (latest notes)
+              type: number
+              description: The page number to show, if there are more than 1 page of notes.
+        """
+        db_records = c.query_unexpired_records(types=RecordType.perma)
+
+        records_pages = Pagination(db_records, self.NOTES_PAGE_SIZE, True)
+        if page is not None:
+            records_pages.page = max(1, min(records_pages.total_pages, page)) - 1
+
+        await self.show_record_page(
+            ctx.message.channel,
+            records=records_pages, user=None, title='Active Permanent Bans'
         )
 
     @notes.command(pass_context=True, aliases=['a'])

--- a/kaztron/cog/modtools.py
+++ b/kaztron/cog/modtools.py
@@ -118,8 +118,12 @@ class ModTools(KazCog):
     async def say(self, ctx: commands.Context, channel: discord.Channel, *, message: str):
         """!kazhelp
 
-        description: Make the bot say something in a channel. If the {{%reminders}} cog is enabled,
+        description: |
+            Make the bot say something in a channel. If the {{%reminders}} cog is enabled,
             you can also schedule a message at a later time with {{!saylater}}.
+
+            If the bot has pin permissions, prepending `pin:` to the beginning of the message will
+            allow it to auto-pin the message.
         parameters:
             - name: channel
               type: string
@@ -130,11 +134,24 @@ class ModTools(KazCog):
                 formatting, @mentions, commands that OTHER bots might react to, and @everyone/@here
                 (if the bot is allowed to use them)."
         examples:
-            - command: .say #meta HELLO, HUMANS. I HAVE GAINED SENTIENCE.
-              description: Says the message in the #meta channel.
+            - command: ".say #meta HELLO, HUMANS. I HAVE GAINED SENTIENCE."
+              description: "Says the message in the #meta channel."
+            - command: ".say #meta pin: REMEMBER TO KEEP HYDRATED."
+              description: "Says the message in the #meta channel and pin it."
         """
-        await self.send_message(channel, message)
+        pin = False
+        if message[:4].lower() == 'pin:':
+            pin = True
+            message = message[4:]
+
+        posted_messages = await self.send_message(channel, message)
         await self.send_output(f"Said in {channel} ({ctx.message.author.mention}): {message}")
+
+        if pin:
+            try:
+                await self.bot.pin_message(posted_messages[0])
+            except discord.Forbidden:
+                logger.warning("Can't pin: missing permissions.")
 
     @commands.command(pass_context=True, ignore_extra=False)
     @mod_only()

--- a/kaztron/cog/modtools.py
+++ b/kaztron/cog/modtools.py
@@ -161,7 +161,8 @@ class ModTools(KazCog):
     async def say(self, ctx: commands.Context, channel: discord.Channel, *, message: str):
         """!kazhelp
 
-        description: Make the bot say something in a channel.
+        description: Make the bot say something in a channel. If the {{%reminders}} cog is enabled,
+            you can also schedule a message at a later time with {{!saylater}}.
         parameters:
             - name: channel
               type: string

--- a/kaztron/cog/modtools.py
+++ b/kaztron/cog/modtools.py
@@ -59,6 +59,7 @@ class ModTools(KazCog):
         - report
         - up
         - down
+        - say
         - tempban
         - whois
         - wb
@@ -153,6 +154,29 @@ class ModTools(KazCog):
             logger.warning(err_msg)
             await self.bot.say("That command is only available to mods and admins.")
             await self.send_output("[WARNING] " + err_msg)
+
+    @commands.command(pass_context=True)
+    @mod_only()
+    @mod_channels()
+    async def say(self, ctx: commands.Context, channel: discord.Channel, *, message: str):
+        """!kazhelp
+
+        description: Make the bot say something in a channel.
+        parameters:
+            - name: channel
+              type: string
+              description: The channel to say the message in.
+            - name: message
+              type: string
+              description: "The message to say. This will be copied exactly. This includes any
+                formatting, @mentions, commands that OTHER bots might react to, and @everyone/@here
+                (if the bot is allowed to use them)."
+        examples:
+            - command: .say #meta HELLO, HUMANS. I HAVE GAINED SENTIENCE.
+              description: Says the message in the #meta channel.
+        """
+        await self.send_message(channel, message)
+        await self.send_output(f"Said in {channel} ({ctx.message.author.mention}): {message}")
 
     def _get_tempbanned_members_db(self, server: discord.Server) -> List[model.Record]:
         if self.notes:

--- a/kaztron/cog/modtools.py
+++ b/kaztron/cog/modtools.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import logging
 import random
 from typing import List, Dict, Optional
@@ -7,20 +6,16 @@ import discord
 from discord import Member
 from discord.ext import commands
 
-from kaztron import KazCog, task
-from kaztron.cog.modnotes.model import RecordType
+from kaztron import KazCog
 from kaztron.cog.modnotes.modnotes import ModNotes
 from kaztron.cog.modnotes import controller, model
 from kaztron.config import SectionView
-from kaztron.errors import BotCogError
-from kaztron.kazcog import ready_only
 from kaztron.theme import solarized
 from kaztron.utils.checks import mod_only, mod_channels, pm_only
 from kaztron.utils.converter import MemberConverter2
 from kaztron.utils.discord import get_named_role, Limits
 from kaztron.utils.embeds import EmbedSplitter
 from kaztron.utils.logging import message_log_str
-from kaztron.utils.strings import parse_keyword_args
 
 logger = logging.getLogger(__name__)
 
@@ -38,9 +33,7 @@ class ModToolsConfig(SectionView):
         element list ["url", "artist name/attribution"].
     """
     distinguish_map: Dict[str, str]
-    tempban_role: str
     notif_role: str
-    channel_mod: str
     wb_images: List[List[str]]
 
 
@@ -49,18 +42,13 @@ class ModTools(KazCog):
     category: Moderator
     brief: Miscellaneous tools for moderators.
     description: |
-        Various tools for moderators to help them in their day-to-day! Some commands are
-        dependent on the {{%ModNotes}} module.
-
-        This module will automatically enforce modnotes of type "temp", at startup and every hour
-        hence. Use {{!tempban}} in order to immediately apply and enforce a new tempban. (Using
-        {{!notes add}} to add a "temp" record will not enforce it until the next hourly check.)
+        Various tools for moderators to help them in their day-to-day! Some commands depend on the
+        {{%ModNotes}} module.
     contents:
         - report
         - up
         - down
         - say
-        - tempban
         - whois
         - wb
     """
@@ -69,42 +57,11 @@ class ModTools(KazCog):
     def __init__(self, bot):
         super().__init__(bot, 'modtools', ModToolsConfig)
         self.cog_config.set_defaults(distinguish_map={}, wb_images=tuple())
-        self.ch_mod = discord.Object(self.cog_config.channel_mod)
         self.cog_modnotes: ModNotes = None
-        self.notes = None
-        self.tempban_role: discord.Role = None
 
     async def on_ready(self):
         await super().on_ready()
-        try:
-            await self.check_for_modnotes()
-        except RuntimeError:
-            await self.send_output(
-                "**ERROR**: Can't find ModNotes cog. The `.tempban` command and automatic tempban "
-                "management will not work. `.whois` reverted to basic functionality."
-            )
-        self.tempban_role = get_named_role(self.server, self.cog_config.tempban_role)
-        self.ch_mod = self.validate_channel(self.ch_mod.id)
-
-        # schedule tempban update tick (unless already done i.e. reconnects)
-        if self.cog_modnotes and not self.scheduler.get_instances(self.task_update_tempbans):
-            self.scheduler.schedule_task_in(self.task_update_tempbans, 0, every=3600)
-
-    async def check_for_modnotes(self):
-        logger.debug("Getting modnotes cog")
-        self.cog_modnotes = self.bot.get_cog("ModNotes")
-        if self.cog_modnotes is None:
-            logger.error("Can't find ModNotes cog.")
-            raise RuntimeError("Can't find ModNotes cog")
-        else:
-            self.notes = controller
-
-    def unload_kazcog(self):
-        self.scheduler.cancel_all(self.task_update_tempbans)
-
-    @ready_only
-    async def on_member_join(self, member: discord.Member):
-        await self._update_tempbans()
+        self.cog_modnotes = self.get_cog_dependency(ModNotes.__name__)
 
     @commands.command(pass_context=True)
     @mod_only()
@@ -179,119 +136,6 @@ class ModTools(KazCog):
         await self.send_message(channel, message)
         await self.send_output(f"Said in {channel} ({ctx.message.author.mention}): {message}")
 
-    def _get_tempbanned_members_db(self, server: discord.Server) -> List[model.Record]:
-        if self.notes:
-            records = self.notes.query_unexpired_records(types=RecordType.temp)
-            members_raw = (server.get_member(record.user.discord_id) for record in records)
-            return [m for m in members_raw if m is not None]
-        else:
-            raise BotCogError("ModNotes cog not loaded. This command requires ModNotes to run.")
-
-    def _get_tempbanned_members_server(self, server: discord.Server) -> List[discord.Member]:
-        return [m for m in server.members if self.tempban_role in m.roles]
-
-    @task(is_unique=True)
-    async def task_update_tempbans(self):
-        await self._update_tempbans()
-
-    async def _update_tempbans(self):
-        """
-        Check and update all current tempbans in modnotes. Unexpired tempbans will be applied and
-        expired tempbans will be removed, when needed.
-        """
-        logger.info("Checking all tempbans.")
-        try:
-            server = self.bot.get_channel(self.ch_mod.id).server  # type: discord.Server
-        except AttributeError:  # get_channel failed
-            logger.error("Can't find mod channel")
-            await self.send_output("**ERROR**: update_tempbans: can't find mod channel")
-            return
-
-        bans_db = self._get_tempbanned_members_db(server)
-        bans_server = self._get_tempbanned_members_server(server)
-
-        # check if any members who need to be banned
-        for member in bans_db:
-            if member not in bans_server:
-                logger.info("Applying tempban role '{role}' to {user!s}...".format(
-                    role=self.tempban_role.name,
-                    user=member
-                ))
-                await self.bot.add_roles(member, self.tempban_role)
-                await self.bot.send_message(self.ch_mod, "Tempbanned {.mention}".format(member))
-
-        # check if any members who need to be unbanned
-        for member in bans_server:
-            if member not in bans_db:
-                logger.info("Removing tempban role '{role}' to {user!s}...".format(
-                    role=self.tempban_role.name,
-                    user=member
-                ))
-                await self.bot.remove_roles(member, self.tempban_role)
-                await self.bot.send_message(self.ch_mod, "Unbanned {.mention}".format(member))
-
-    @commands.command(pass_context=True)
-    @mod_only()
-    @mod_channels()
-    async def tempban(self, ctx: commands.Context, user: str, *, reason: str=""):
-        """!kazhelp
-
-        description: |
-            Tempban a user.
-
-            This command will immediately tempban (mute) the user, and create a modnote. It will not
-            communicate with the user.
-
-            The user will be unbanned (unmuted) when the tempban expires.
-
-            Note that the ModTools module automatically enforces all tempban modules. See the
-            {{%ModTools}} introduction or `.help ModTools` for more info.
-
-            This command is shorthand for `.notes add <user> temp expires="[expires]" [reason]`.
-        parameters:
-            - name: user
-              type: string
-              description: The user to ban. See {{!notes}} for more information.
-            - name: reason
-              type: string
-              optional: true
-              description: "Complex parameter of the format `[expires=[expires]] [reason]`. `reason`
-                is the reason for the tempban, to be recorded as a modnote (optional but highly
-                recommended)."
-            - name: expires
-              type: datespec
-              optional: true
-              description: "The datespec for the tempban's expiration. Use quotation marks if the
-                datespec has spaces in it. See {{!notes add}} for more information on accepted
-                syntaxes."
-              default: '"in 7 days"'
-        examples:
-            - command: .tempban @BlitheringIdiot#1234 Was being a blithering idiot.
-              description: Issues a 7-day ban.
-            - command: .tempban @BlitheringIdiot#1234 expires="in 3 days" Was being a slight
-                blithering idiot only.
-              description: Issues a 3-day ban.
-        """
-        if not self.cog_modnotes:
-            raise BotCogError("ModNotes cog not loaded. This command requires ModNotes to run.")
-
-        # Parse and validate kwargs (we won't use this, just want to validate valid keywords)
-        try:
-            kwargs, rem = parse_keyword_args(self.cog_modnotes.KW_EXPIRE, reason)
-        except ValueError as e:
-            raise commands.BadArgument(e.args[0]) from e
-        else:
-            if not kwargs:
-                reason = 'expires="{}" {}'.format("in 7 days", reason)
-            if not rem:
-                reason += " No reason specified."
-
-        # Write the note
-        await ctx.invoke(self.cog_modnotes.add, user, 'temp', note_contents=reason)
-
-        # Apply new mutes
-        await self._update_tempbans()
-
     @commands.command(pass_context=True, ignore_extra=False)
     @mod_only()
     @mod_channels()
@@ -325,7 +169,7 @@ class ModTools(KazCog):
         search_users = self._whois_search(ctx, user)  # partial match
         st = user[:Limits.NAME]
         if self.cog_modnotes:  # search modnotes
-            notes_users = self.notes.search_users(st)
+            notes_users = controller.search_users(st)
             notes_map = {}
             notes_orphans = []
             for u in notes_users:
@@ -412,7 +256,7 @@ class ModTools(KazCog):
 
     async def _whois_find_notes_id(self, member: discord.Member):
         if self.cog_modnotes:
-            db_user = await self.notes.query_user(self.bot, member.id)
+            db_user = await controller.query_user(self.bot, member.id)
             return db_user.user_id
         else:
             return None
@@ -499,7 +343,7 @@ class ModTools(KazCog):
             author = image_data[1]
             logger.debug("wb: displaying image {:d}".format(index))
             await self.bot.say(image_url)
-            await self.bot.say("_Artist: {}_ (Image #{})".format(author.replace('_', '\_'), index))
+            await self.bot.say("_Artist: {}_ (Image #{})".format(author.replace('_', r'\_'), index))
             await self.bot.delete_message(ctx.message)
 
     @commands.command(pass_context=True, ignore_extra=False)
@@ -542,7 +386,7 @@ class ModTools(KazCog):
             logger.warning("Notification role not found: {}".format(self.cog_config.notif_role))
             await self.send_output('[WARNING] Notif role not found: {}'
                 .format(self.cog_config.notif_role))
-        await self.send_message(self.ch_mod, notif_role_mention, embed=es)
+        await self.send_message(self.cog_config.channel_mod, notif_role_mention, embed=es)
         await self.send_message(
             ctx.message.channel,
             "Thank you. I've forwarded your report to the mods, who will handle it shortly. You "

--- a/kaztron/cog/projects/projects.py
+++ b/kaztron/cog/projects/projects.py
@@ -285,7 +285,7 @@ class ProjectsManager(KazCog):
 
     async def on_ready(self):
         await super().on_ready()
-        self.channel = self.validate_channel(self.channel_id)
+        self.channel = self.get_channel(self.channel_id)
         await self._update_unsent_projects()
         self.wizard_manager = self.cog_state.wizards
 

--- a/kaztron/cog/reminder.py
+++ b/kaztron/cog/reminder.py
@@ -3,7 +3,7 @@ import logging
 import re
 from datetime import datetime, timedelta
 from functools import reduce
-from typing import List, Tuple
+from typing import List, Tuple, Dict
 
 import discord
 from discord.ext import commands
@@ -21,54 +21,197 @@ from kaztron.utils.strings import format_list
 logger = logging.getLogger(__name__)
 
 
+class RenewData:
+    def __init__(self, *, interval: timedelta, limit: int, limit_time: datetime):
+        self.interval = interval
+        self.limit = limit
+        self.limit_time = limit_time
+
+    def to_dict(self):
+        return {
+            'interval': self.interval.total_seconds(),
+            'limit': self.limit,
+            'limit_time': utctimestamp(self.limit_time) if self.limit_time else None
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        return cls(
+            interval=timedelta(seconds=data['interval']),
+            limit=data.get('limit', 0),
+            limit_time=data.get('limit_time', None)
+        )
+
+    def __repr__(self):
+        return "<RenewData(interval={}, limit={}, limit_time={})>" \
+            .format(self.interval, self.limit, self.limit_time)
+
+    def str_dict(self) -> Dict[str, str]:
+        return {
+            'interval': format_timedelta(self.interval) if self.interval else '',
+            'limit': '{:d}'.format(self.limit) if self.limit else '',
+            'limit_time': format_datetime(self.limit_time) if self.limit_time else ''
+        }
+
+
 class ReminderData:
     MSG_LIMIT = Limits.MESSAGE - 75
 
     def __init__(self,
                  *,
                  user_id: str,
-                 channel_id: str,
+                 channel_id: str = None,
                  timestamp: datetime,
                  remind_time: datetime,
+                 renew_data: RenewData,
                  msg: str
                  ):
         self.user_id = user_id
         self.channel_id = channel_id
         self.timestamp = timestamp
         self.remind_time = remind_time
+        self.renew_data = renew_data
         self.message = msg[:self.MSG_LIMIT]
         self.retries = 0
 
     def to_dict(self):
-        return {
+        data = {
             'user_id': self.user_id,
             'channel_id': self.channel_id,
             'timestamp': utctimestamp(self.timestamp),
             'remind_time': utctimestamp(self.remind_time),
+            'renew': self.renew_data.to_dict() if self.renew_data else None,
             'message': self.message
         }
-
-    def __repr__(self):
-        return "<ReminderData(user_id={}, channel_id={}, "\
-               "timestamp={}, remind_time={}, message={!r})>"\
-            .format(self.user_id, self.channel_id,
-                    self.timestamp.isoformat(' '),
-                    self.remind_time.isoformat(' '),
-                    self.message)
+        return data
 
     @classmethod
     def from_dict(cls, data: dict):
         return cls(
-            user_id=data.get('channel_id', ''),
+            user_id=data.get('user_id', ''),
             channel_id=data.get('channel_id', ''),
             timestamp=datetime.utcfromtimestamp(data['timestamp']),
             remind_time=datetime.utcfromtimestamp(data['remind_time']),
+            renew_data=RenewData.from_dict(data['renew']) if data.get('renew', None) else None,
             msg=data['message']
         )
+
+    def __repr__(self):
+        return "<ReminderData(user_id={}, channel_id={}, " \
+               "timestamp={}, remind_time={}, renew={!r}, message={!r})>" \
+            .format(self.user_id, self.channel_id,
+                    self.timestamp.isoformat(' '),
+                    self.remind_time.isoformat(' '),
+                    self.renew_data,
+                    self.message)
+
+    def str_dict(self) -> Dict[str, str]:
+        return {
+            'user': user_mention(self.user_id) if self.user_id else '',
+            'channel': channel_mention(self.channel_id) if self.channel_id else 'PM',
+            'timestamp': format_datetime(self.timestamp),
+            'remind_time': format_datetime(self.remind_time),
+            'message': self.message
+        }
+
+    def is_match(self, user_id: str=None, channel_id: str=None):
+        """
+        Check if reminder matches criteria.
+
+        If only a user_id is provided, returns True if the reminder is a private reminder for that
+        user.
+
+        If a channel_id is provided, returns True if the reminder is a channel message for that
+        channel. This check can further be filtered by the user who set the reminder, if user_id is
+        also provided.
+        """
+        return self.channel_id == channel_id and (user_id is None or self.user_id == user_id)
+
+
+class ReminderParser:
+    MAX_TIMESPEC = timedelta(weeks=521)  # 10 years
+    RE_ARGS = re.compile(r'(?P<timespec>.*?)'
+                         r'(\s+'
+                            r'every\s+(?P<renew_interval>.*?)'
+                            r'(\s+limit\s+(?P<limit>\d+)|\s+until\s+(?P<limit_time>.*?))?'
+                         r')?\s*:\s+(?P<msg>.*)$')
+
+    @classmethod
+    def parse(cls, args: str, now: datetime) -> Tuple[datetime, Tuple[timedelta, int, datetime], str]:
+        """
+        Parse reminder args.
+        :return: (timespec, (renew_interval, renew_limit, renew_limit_time), msg)
+        """
+        args = cls.RE_ARGS.match(args)  # type: re.Match
+        if args is None:
+            raise commands.BadArgument("message")
+
+        timespec = cls._parse_timespec(args.group('timespec'), now)
+
+        if args.group('renew_interval'):
+            renew = cls._parse_renew(args.group('renew_interval'),
+                                     args.group('limit'),
+                                     args.group('limit_time'),
+                                     now)
+        else:
+            renew = None
+        return timespec, renew, args.group('msg')
+
+    @classmethod
+    def _parse_timespec(cls, timespec_s: str, now: datetime):
+        max_timestamp = now + cls.MAX_TIMESPEC
+        # first one allows "10 minutes" as a future input, second is a fallback
+        try:
+            timespec = dt_parse('in '+timespec_s, future=True) or dt_parse(timespec_s, future=True)
+        except ValueError:
+            # usually raised by datetime, for range issues
+            # the parser will usually return None if parsing fails
+            raise commands.BadArgument("range", timespec_s[:64])
+
+        if timespec is None:
+            raise commands.BadArgument("timespec", timespec_s[:64])
+        elif timespec <= now:
+            raise commands.BadArgument("past", timespec_s[:64])
+        elif timespec >= max_timestamp:
+            raise commands.BadArgument("range", timespec_s[:64])
+
+        return timespec
+
+    @classmethod
+    def _parse_renew(cls, interval_s: str, limit_s: str, limit_time_s: str, now: datetime):
+        # process the renewal time: use dateparser and then figure out the delta
+        try:
+            timespec = dt_parse('in' + interval_s, future=True,
+                                PARSERS=['relative-time'], RELATIVE_BASE=now)
+            interval = timespec - now  # type: timedelta
+        except ValueError:
+            raise commands.BadArgument("range", interval_s[:64])
+
+        if interval is None:
+            raise commands.BadArgument("timespec", interval_s[:64])
+        elif interval.total_seconds() < 0:
+            raise commands.BadArgument("renew_interval_neg", interval_s[:64])
+        elif interval >= cls.MAX_TIMESPEC:
+            raise commands.BadArgument("range", interval_s[:64])
+
+        try:
+            limit = int(limit_s) if limit_s is not None else None
+        except ValueError:
+            raise commands.BadArgument("renew_limit")
+
+        limit_time = cls._parse_timespec(limit_time_s, now) if limit_time_s is not None else None
+
+        return interval, limit, limit_time
 
 
 class ReminderState(SectionView):
     reminders: List[ReminderData]
+
+
+class ReminderConfig(SectionView):
+    max_per_user: int        # maximum personal reminders per user
+    renew_limit: int         # maximum times a reminder or saylater can repeat
+    renew_interval_min: int  # minimum interval for recurring reminders/saylater (seconds)
 
 
 class Reminders(KazCog):
@@ -86,25 +229,47 @@ class Reminders(KazCog):
     contents:
         - reminder:
             - list
+            - rem
             - clear
         - saylater:
             - list
             - rem
     """
     cog_state: ReminderState
+    cog_config: ReminderConfig
 
-    MAX_PER_USER = 10
     MAX_RETRIES = 10
     RETRY_INTERVAL = 90
 
+    ###
+    # LIFECYCLE
+    ###
     def __init__(self, bot):
-        super().__init__(bot, 'reminders', state_section_view=ReminderState)
+        super().__init__(bot, 'reminders', ReminderConfig, ReminderState)
+        self.cog_config.set_defaults(
+            max_per_user=10,
+            renew_limit=25,
+            renew_interval_min=600
+        )
         self.cog_state.set_defaults(reminders=[])
         self.cog_state.set_converters('reminders',
             lambda l: [ReminderData.from_dict(r) for r in l],
             lambda l: [r.to_dict() for r in l]
         )
         self.reminders = []  # type: List[ReminderData]
+
+    async def on_ready(self):
+        await super().on_ready()
+        if not self.reminders:
+            self._load_reminders()
+
+    def export_kazhelp_vars(self):
+        interval_s = format_timedelta(timedelta(seconds=self.cog_config.renew_interval_min))
+        return {
+            "max_per_user": f'{self.cog_config.max_per_user:d}',
+            "renew_limit": f'{self.cog_config.renew_limit:d}',
+            "renew_interval_min": interval_s
+        }
 
     def _load_reminders(self):
         logger.info("Loading reminders from persisted state...")
@@ -124,121 +289,59 @@ class Reminders(KazCog):
         self.cog_state.reminders = self.reminders
         self.state.write()
 
-    async def on_ready(self):
-        await super().on_ready()
-        if not self.reminders:
-            self._load_reminders()
+    ###
+    # GENERAL UTILITY FUNCTIONS
+    ###
 
-    def parse_reminder_args(self, args: str) -> Tuple[datetime, str]:
+    def get_count(self, user_id: str = None, channel_id: str = None):
+        """ Get number of reminders matching criteria. """
+        return reduce(lambda c, r: c+1 if r.is_match(user_id, channel_id) else c, self.reminders, 0)
+
+    def get_matching(self, user_id: str = None, channel_id: str = None):
+        """ Get list of reminders matching criteria, in ascending order of remind time. """
+        return sorted(filter(lambda r: r.is_match(user_id, channel_id), self.reminders),
+                      key=lambda r: r.remind_time)
+
+    @property
+    def saylaters(self):
+        return sorted(filter(lambda r: r.channel_id, self.reminders), key=lambda r: r.remind_time)
+
+    @property
+    def personal_reminders(self):
+        return sorted(filter(lambda r: not r.channel_id, self.reminders),
+                      key=lambda r: r.remind_time)
+
+    def make_reminder(self, ctx: commands.Context, args: str, channel: discord.Channel = None):
         """
-        Parse reminder args.
-
-        :return: (timespec, msg)"""
-        try:
-            timespec_s, msg = re.split(r':\s+|,', args, maxsplit=1)
-        except ValueError:
-            raise commands.BadArgument("message")
-
-        timestamp = datetime.utcnow()
-        max_timestamp = timestamp + timedelta(weeks=521)
-        # first one allows "10 minutes" as a future input, second is a fallback
-        try:
-            timespec = dt_parse('in '+timespec_s, future=True) or dt_parse(timespec_s, future=True)
-        except ValueError:
-            # usually raised by datetime, for range issues
-            # the parser will usually return None if parsing fails
-            raise commands.BadArgument("range")
-
-        if timespec is None:
-            raise commands.BadArgument("timespec", timespec_s[:64])
-        elif timespec <= timestamp:
-            raise commands.BadArgument("past")
-        elif timespec >= max_timestamp:
-            raise commands.BadArgument("range")
-
-        return timespec, msg
-
-    @commands.group(pass_context=True, invoke_without_command=True)
-    @mod_only()
-    @mod_channels()
-    async def saylater(self, ctx: commands.Context, channel: discord.Channel, *, args: str):
-        """!kazhelp
-
-        description: |
-            Schedule a message for the bot to send in-channel later.
-
-            TIP: You should double-check the reminder time, to make sure your timespec was
-            interpreted correctly.
-        parameters:
-            - name: channel
-              description: The channel to post the message in.
-            - name: args
-              description: "Consists of `<timespec>: <message>`. Same as for {{!reminder}}."
-        examples:
-            - command: ".saylater #community-programs at 12:00 UTC:
-                Welcome to our AMA with philosopher Aristotle!"
+        Prepare ReminderData for any kind of reminder (channel or private/PM).
+        :param ctx: Command context.
+        :param args: Full reminder argument string, of the form "<timespec>: <message>" (or
+                    extended for recurring reminders).
+        :param channel: Optional. If specified, creates a channel reminder. Otherwise, creates a
+                    personal reminder.
+        :return:
         """
-        timespec, msg = self.parse_reminder_args(args)
+        ctx.message: discord.Message
+        timestamp = ctx.message.timestamp
+        renew_data = None
+
+        # parse arguments
+        timespec, renew, msg = ReminderParser.parse(args, timestamp)
+        if renew:
+            renew_data = RenewData(interval=renew[0], limit=renew[1], limit_time=renew[2])
+            # enforce limits
+            if renew_data.interval.total_seconds() < self.cog_config.renew_interval_min:
+                raise commands.BadArgument("renew_interval_min", renew_data.interval)
+            if not renew_data.limit or not (0 < renew_data.limit <= self.cog_config.renew_limit):
+                logger.warning(f"Reminder limit ({renew_data.limit}) invalid: setting to "
+                f"configured maximum {self.cog_config.renew_limit}")
+                renew_data.limit = self.cog_config.renew_limit
+
         reminder = ReminderData(
-            user_id=ctx.message.author.id, channel_id=channel.id,
-            timestamp=datetime.utcnow(), remind_time=timespec, msg=msg
+            user_id=ctx.message.author.id, channel_id=channel.id if channel else None,
+            renew_data=renew_data, timestamp=timestamp, remind_time=timespec, msg=msg
         )
-        self.add_reminder(reminder)
-        await self.send_message(ctx.message.channel,
-            "Got it! I'll post that in {} at {} UTC (in {!s}).".format(
-                channel.mention, format_datetime(reminder.remind_time),
-                format_timedelta(reminder.remind_time - datetime.utcnow())
-            ))
-
-    @commands.group(pass_context=True, invoke_without_command=True, aliases=['remind'])
-    async def reminder(self, ctx: commands.Context, *, args: str):
-        """!kazhelp
-
-        description: |
-            Sends you a personal reminder by PM at some point in the future.
-
-            TIP: Make sure you've enabled "Allow direct messages from server members" for the server
-            the bot is on.
-
-            TIP: You should double-check the reminder time in the confirmation PM, to make sure your
-            timespec was interpreted correctly.
-        parameters:
-            - name: args
-              description: "Consists of `<timespec>: <message>`."
-            - name: timespec
-              type: timespec
-              description: |
-                  A time in the future to send you a reminder, followed by a colon and a
-                  space. This can be an absolute date and time `2018-03-07 12:00:00`, a relative
-                  time `in 2h 30m` (the "in" **and** the spaces are important), or combinations of
-                  the two (`tomorrow at 1pm`). If giving an absolute time, you can specify a time
-                  zone (e.g. `1pm UTC-5` or `13:05 EST`); if none specified, default is UTC.
-            - name: message
-              type: string
-              description: The message you want to be reminded with.
-        examples:
-            - command: ".remind in 2 hours: Feed the dog"
-            - command: ".remind on 24 december at 4:50pm: Grandma's Christmas call"
-            - command: ".remind tomorrow at 8am PST: start spotlight"
-        """
-        # check existing count
-        n = reduce(lambda c, r: c+1 if r.user_id == ctx.message.author.id else c, self.reminders, 0)
-        if n >= self.MAX_PER_USER:
-            logger.warning("Cannot add reminder: user {} at limit".format(ctx.message.author))
-            await self.bot.say(("Oops! You already have too many future reminders! "
-                         "The limit is {:d} per person.").format(self.MAX_PER_USER))
-            return
-        timespec, msg = self.parse_reminder_args(args)
-        reminder = ReminderData(
-            user_id=ctx.message.author.id, channel_id='',
-            timestamp=datetime.utcnow(), remind_time=timespec, msg=msg
-        )
-        self.add_reminder(reminder)
-        await self.send_message(ctx.message.channel,
-            "Got it! I'll remind you by PM at {} UTC (in {!s}).".format(
-                format_datetime(reminder.remind_time),
-                format_timedelta(reminder.remind_time - datetime.utcnow())
-        ))
+        return reminder
 
     def add_reminder(self, r: ReminderData):
         self.reminders.append(r)
@@ -247,28 +350,231 @@ class Reminders(KazCog):
         self._save_reminders()
         logger.info("Set reminder: {!r}".format(r))
 
+    def remove_reminder(self, r: ReminderData):
+        """ Remove reminder. Parameter must be exact object. """
+        for inst in self.scheduler.get_instances(self.task_reminder_expired):  # type: TaskInstance
+            if inst.args[0] is r:
+                try:
+                    inst.cancel()
+                except asyncio.InvalidStateError:
+                    pass
+                self.reminders.remove(r)
+                break
+        self._save_reminders()
+
+    @staticmethod
+    def format_list(reminders: List[ReminderData]) -> str:
+        """ Format the input list for sending to a user. """
+        items = []
+        for reminder in reminders:
+            build_str = []
+
+            if reminder.channel_id:
+                build_str.append("In {channel} at {timestamp} UTC (in {delta})")
+            else:
+                build_str.append("At {timestamp} UTC (in {delta})")
+
+            if reminder.renew_data:
+                renew_data = reminder.renew_data
+                build_str.append(" and every {interval}")
+                if renew_data.limit_time:
+                    build_str.append(" until {limit_time} up to")
+                build_str.append(" {limit} times")
+
+            build_str.append(": {message}")
+
+            items.append(''.join(build_str).format(
+                delta=format_timedelta(reminder.remind_time - datetime.utcnow()),
+                **reminder.str_dict(),
+                **(reminder.renew_data.str_dict() if reminder.renew_data else {})
+            ))
+        return format_list(items) if items else 'None'
+
+    ###
+    # COMMANDS
+    ###
+
+    @commands.group(pass_context=True, invoke_without_command=True, aliases=['remind'])
+    async def reminder(self, ctx: commands.Context, *, args: str):
+        """!kazhelp
+
+        description: |
+            Sends you a personal reminder by PM at some point in the future. This function can also
+            set up recurring reminders.
+
+            Each user can have a maximum of {{max_per_user}} reminders. Recurring reminders can
+            repeat up to {{renew_limit}} times, and cannot repeat more often than every
+            {{renew_interval_min}}.
+
+            TIP: Make sure you've enabled "Allow direct messages from server members" for the server
+            the bot is on.
+
+            TIP: You should double-check the reminder time in the confirmation PM, to make sure your
+            timespec was interpreted correctly.
+        parameters:
+            - name: args
+              description: "Multi-part argument consists of `<timespec> [\\"every\\" <intervalspec>
+                    [\\"limit\\" <limit>|\\"until\\" <limit_timespec>]: <message>`."
+            - name: timespec
+              type: timespec
+              description: |
+                  A time in the future to send you a reminder, followed by
+                  a colon and a space. This can be an absolute date and time `2018-03-07 12:00:00`,
+                  a relative time `in 2h 30m` (the "in" **and** the spaces are important), or
+                  combinations of the two (`tomorrow at 1pm`). If giving an absolute time, you can
+                  specify a time zone (e.g. `1pm UTC-5` or `13:05 EST`); if none specified, default
+                  is UTC.
+            - name: intervalspec
+              type: timespec
+              optional: true
+              description: |
+                How often the reminder should repeat after the `timespec`. Can take any relative
+                time specification accepted by `timespec`, e.g., `every 1 hour`, `every 4h 30m`,
+                etc.
+            - name: limit
+              type: int
+              optional: true
+              description: How many times the reminder will repeat. Only one of `limit` or
+                `limitspec` may be used.
+            - name: limitspec
+              type: timespec
+              optional: true
+              description: The latest time at which the reminder will repeat. Accepts the same
+                values  as `timespec`. Only one of `limit` or `limitspec` may be used.
+            - name: message
+              type: string
+              description: The message you want to be reminded with.
+        examples:
+            - command: ".remind on 24 december at 4:50pm: Grandma's Christmas call"
+              description: Date and time. Assumes nearest future date. Time is interpreted as UTC.
+            - command: ".remind in 2 hours: Feed the dog"
+              description: Relative time.
+            - command: ".remind tomorrow at 8am PST: start spotlight"
+              description: Relative date, absolute time, time zone specified.
+            - command: ".remind in 2 hours every 1 hour limit 8: drink water, you dehydrated prune"
+              description: Reminder starting in 2 hours, repeating every 1 hour, 8 times total.
+            - command: ".remind 22:00 EDT every 1 hour until 08:00 EDT: Remember to sleep"
+              description: Reminder every hour between 10PM tonight and 8AM tomorrow.
+        """
+        if self.get_count(user_id=ctx.message.author.id) >= self.cog_config.max_per_user:
+            raise commands.UserInputError('max_per_user')
+
+        reminder = self.make_reminder(ctx, args)
+        self.add_reminder(reminder)
+
+        # set message
+        if not reminder.renew_data:
+            reply = "Got it! I'll remind you by PM at {timestamp} UTC (in {delta}).".format(
+                delta=format_timedelta(reminder.remind_time - reminder.timestamp),
+                **reminder.str_dict()
+            )
+        else:
+            if not reminder.renew_data.limit_time:
+                replyf = "Got it! I'll remind you by PM at {timestamp} UTC (in {delta}), " \
+                         "then every {interval} up to {limit} times."
+            else:
+                replyf = "Got it! I'll remind you by PM at {timestamp} UTC (in {delta}), " \
+                         "then every {interval} until {limit_time} or up to {limit} times."
+            reply = replyf.format(
+                delta=format_timedelta(reminder.remind_time - reminder.timestamp),
+                **reminder.str_dict(),
+                **reminder.renew_data.str_dict()
+            )
+
+        await self.send_message(ctx.message.channel, reply)
+
+    @commands.group(pass_context=True, invoke_without_command=True)
+    @mod_only()
+    @mod_channels()
+    async def saylater(self, ctx: commands.Context, channel: discord.Channel, *, args: str):
+        """!kazhelp
+
+        description: |
+            Schedule a message for the bot to send in-channel later. Can also set up recurring
+            messages (static messages only).
+
+            Recurring messages can repeat up to {{renew_limit}} times, and cannot repeat more often
+            than every {{renew_interval_min}}s.
+
+            TIP: You should double-check the time in the response message to make sure your timespec
+            was interpreted correctly.
+        parameters:
+            - name: channel
+              description: The channel to post the message in.
+            - name: args
+              description: Same as {{!reminder}}.
+        examples:
+            - command: ".saylater #community-programs at 12:00:
+                Welcome to our AMA with philosopher Aristotle!"
+              description: Single message at noon UTC.
+            - command: ".saylater #announcements at 12:00 every 1 hour limit 24: Attention,
+                citizens. For the duration of gremlin season, all citizens must be on the lookout
+                for crown-stealing gremlins. Any sightings or incidents must be reported to your
+                nearest moderator immediately."
+              description: Recurring message every hour starting at noon UTC.
+        """
+
+        reminder = self.make_reminder(ctx, args, channel)
+        self.add_reminder(reminder)
+
+        # set message
+        if not reminder.renew_data:
+            reply = "Got it! I'll post that in {channel} at {timestamp} UTC (in {delta}).".format(
+                delta=format_timedelta(reminder.remind_time - reminder.timestamp),
+                **reminder.str_dict()
+            )
+        else:
+            if not reminder.renew_data.limit_time:
+                replyf = "Got it! I'll post that in {channel} at {timestamp} UTC (in {delta}), " \
+                         "then every {interval} up to {limit} times."
+            else:
+                replyf = "Got it! I'll post that in {channel} at {timestamp} UTC (in {delta}), " \
+                         "then every {interval} until {limit_time} or up to {limit} times."
+            reply = replyf.format(
+                delta=format_timedelta(reminder.remind_time - reminder.timestamp),
+                **reminder.str_dict(),
+                **reminder.renew_data.str_dict()
+            )
+
+        await self.send_message(ctx.message.channel, reply)
+
+    @saylater.error
     @reminder.error
     async def reminder_error(self, exc, ctx):
-        if isinstance(exc, commands.BadArgument) and exc.args[0] == 'timespec':
-            logger.error("Passed unknown timespec: {}".format(exc.args[1]))
-            await self.bot.say(
-                ctx.message.author.mention +
-                " Sorry, I don't understand the timespec '{}'".format(exc.args[1])
-            )
-        elif isinstance(exc, commands.BadArgument) and exc.args[0] == 'range':
-            await self.bot.say(
-                ctx.message.author.mention + " Oops, that's too far in the future!"
-            )
-        elif isinstance(exc, commands.BadArgument) and exc.args[0] == 'past':
-            await self.bot.say(
-                ctx.message.author.mention + " Oops! You can't set a reminder in the past!"
-            )
-        elif isinstance(exc, commands.BadArgument) and exc.args[0] == 'message':
-            await self.bot.say(
-                ctx.message.author.mention + " You need to specify a message for your reminder! "
-                "Separate it from the timespec with a colon *and* space: "
-                "`.reminder in 10 minutes: message`"
-            )
+        if isinstance(exc, commands.BadArgument):
+            if exc.args[0] == 'timespec':
+                logger.warning("Passed unknown timespec: {}".format(exc.args[1]))
+                await self.send_message(ctx.message.channel, ctx.message.author.mention +
+                    " Sorry, I don't understand the timespec '{}'".format(exc.args[1])
+                )
+            elif exc.args[0] == 'range':
+                logger.warning("Passed timespec outside range: {}".format(exc.args[1]))
+                await self.send_message(ctx.message.channel, ctx.message.author.mention +
+                    " Sorry, that's too far in the future! I'll forget by then."
+                )
+            elif exc.args[0] == 'past':
+                logger.warning("Passed timespec in the past: {}".format(exc.args[1]))
+                await self.send_message(ctx.message.channel, ctx.message.author.mention +
+                    " Oops! You can't set a reminder in the past."
+                )
+            elif exc.args[0] == 'message':
+                logger.warning("Invalid syntax: {}".format(exc.args[1]))
+                await self.send_message(ctx.message.channel, ctx.message.author.mention +
+                    " You need to specify a message for your reminder! "
+                    "Separate it from the timespec with a colon *and* space: "
+                    "`.reminder in 10 minutes: message`"
+                )
+            elif exc.args[0] == 'renew_interval_neg' or exc.args[0] == 'renew_interval_min':
+                logger.warning("Passed invalid renew interval: {}".format(exc.args[1]))
+                await self.send_message(ctx.message.channel, ctx.message.author.mention +
+                     " Sorry, I can't repeat reminders more often than {}. Don't want to spam you!"
+                     .format(format_timedelta(timedelta(seconds=self.cog_config.renew_interval_min)))
+                 )
+        elif isinstance(exc, commands.UserInputError) and exc.args[0] == 'max_per_user':
+            logger.warning("Cannot add reminder: user {} at limit".format(ctx.message.author))
+            await self.send_message(ctx.message.channel, ctx.message.author.mention +
+                "Sorry, you already have too many future reminders! "
+                "The limit is {:d} per person.".format(self.cog_config.max_per_user))
         else:
             core_cog = self.bot.get_cog("CoreCog")
             await core_cog.on_command_error(exc, ctx, force=True)  # Other errors can bubble up
@@ -304,6 +610,20 @@ class Reminders(KazCog):
         except ValueError:
             logger.warning("task_reminder_expired: Reminder not in list of reminders - "
                            "already removed? {!r}".format(reminder))
+
+        # set up recurring reminder
+        if reminder.renew_data and reminder.renew_data.interval:
+            reminder.remind_time += reminder.renew_data.interval
+            reminder.renew_data.limit -= 1
+            if reminder.renew_data.limit <= 0:
+                logger.debug("Recurring reminder has reached recurrence limit")
+            elif reminder.renew_data.limit_time and \
+                    reminder.remind_time > reminder.renew_data.limit_time:
+                logger.debug("Recurring reminder has reached time limit")
+            else:
+                logger.debug("Setting up recurrence")
+                self.add_reminder(reminder)
+
         self._save_reminders()
 
     @task_reminder_expired.error
@@ -337,45 +657,50 @@ class Reminders(KazCog):
             self.reminders.remove(r)
             self._save_reminders()
 
-    @reminder.command(ignore_extra=False, pass_context=True)
-    async def list(self, ctx: commands.Context):
+    @reminder.command(ignore_extra=False, pass_context=True, name='list')
+    async def reminder_list(self, ctx: commands.Context):
         """!kazhelp
 
          description: |
-            Lists all future reminders you've requested.
-
-            The list is sent by PM.
+            List all your future reminders. The list is sent by PM.
          """
-        items = []
-        filtered = filter(lambda r: r.user_id == ctx.message.author.id, self.reminders)
-        sorted_reminders = sorted(filtered, key=lambda r: r.remind_time)
-        for reminder in sorted_reminders:
-            items.append("At {} UTC (in {}): {}".format(
-                format_datetime(reminder.remind_time),
-                format_timedelta(reminder.remind_time - datetime.utcnow()),
-                reminder.message
-            ))
-        reminder_list = format_list(items) if items else 'None'
 
-        await self.bot.send_message(ctx.message.author, "**Your reminders**\n" + reminder_list)
+        reminder_list = self.format_list(self.get_matching(user_id=ctx.message.author.id))
+        await self.send_message(ctx.message.author, "**Your reminders**\n" + reminder_list,
+                                split='line')
         try:
             await self.bot.delete_message(ctx.message)
         except discord.Forbidden:
             pass  # no permission or in a PM; oh well, this is not critical
 
-    @reminder.command(pass_context=True, ignore_extra=False)
-    async def clear(self, ctx: commands.Context):
+    @saylater.command(ignore_extra=False, pass_context=True, name='list')
+    @mod_only()
+    @mod_channels()
+    async def saylater_list(self, ctx: commands.Context):
+        """!kazhelp
+
+         description: |
+            List all future scheduled messages.
+         """
+        reminder_list = self.format_list(self.saylaters)
+        await self.send_message(ctx.message.channel, "**Scheduled messages**\n" + reminder_list,
+                                split='line')
+        try:
+            await self.bot.delete_message(ctx.message)
+        except discord.Forbidden:
+            pass  # no permission or in a PM; oh well, this is not critical
+
+    @reminder.command(pass_context=True, ignore_extra=False, name='clear')
+    async def reminder_clear(self, ctx: commands.Context):
         """!kazhelp
 
         description: |
-            Remove all future reminders you've requested.
+            Remove all your future reminders.
 
             WARNING: This command cannot be undone.
         """
-        reminders_to_keep = []
-
         for inst in self.scheduler.get_instances(self.task_reminder_expired):  # type: TaskInstance
-            if inst.args[0].user_id == ctx.message.author.id:
+            if inst.args[0].is_match(user_id=ctx.message.author.id):
                 try:
                     inst.cancel()
                 except asyncio.InvalidStateError:
@@ -383,6 +708,107 @@ class Reminders(KazCog):
                 self.reminders.remove(inst.args[0])
         self._save_reminders()
         await self.bot.say("All your reminders have been cleared.")
+
+    @saylater.command(pass_context=True, ignore_extra=False, name='clear')
+    @mod_only()
+    @mod_channels()
+    async def saylater_clear(self, ctx: commands.Context):
+        """!kazhelp
+
+        description: |
+            Remove all scheduled messages.
+
+            WARNING: This removes scheduled messages created by other users, too.
+
+            WARNING: This command cannot be undone.
+        """
+        for inst in self.scheduler.get_instances(self.task_reminder_expired):  # type: TaskInstance
+            if inst.args[0].channel_id:
+                try:
+                    inst.cancel()
+                except asyncio.InvalidStateError:
+                    pass
+                self.reminders.remove(inst.args[0])
+        self._save_reminders()
+        await self.bot.say("All scheduled messages have been cleared.")
+
+    @reminder.command(pass_context=True, ignore_extra=False, name='remove', aliases=['rem'])
+    async def reminder_remove(self, ctx: commands.Context, index: int):
+        """!kazhelp
+
+        description: |
+            Remove a reminder.
+
+            WARNING: This command cannot be undone.
+        parameters:
+            - name: index
+              type: int
+              description: The number of the reminder to remove. See the {{!reminder list}} command
+                  for the numbered list.
+        examples:
+            - command: .reminder rem 4
+              description: Removes reminder number 4.
+        """
+        if index <= 0:
+            await self.send_message(ctx.message.channel, ctx.message.author.mention +
+                " Oops, that reminder doesn't exist!")
+            return
+
+        try:
+            reminder = self.get_matching(user_id=ctx.message.author.id)[index-1]
+        except IndexError:
+            await self.send_message(ctx.message.channel, ctx.message.author.mention +
+                " Oops, that reminder doesn't exist! You only have {:d} reminders."
+                .format(self.get_count(user_id=ctx.message.author.id)))
+            return
+
+        desc = "Removed reminder for {remind_time} UTC (in {delta}): {message}".format(
+                delta=format_timedelta(reminder.remind_time - datetime.utcnow()),
+                **reminder.str_dict()
+            )
+
+        self.remove_reminder(reminder)
+        await self.send_message(ctx.message.channel, ctx.message.author.mention + " " + desc)
+
+    @saylater.command(pass_context=True, ignore_extra=False, name='remove', aliases=['rem'])
+    @mod_only()
+    @mod_channels()
+    async def saylater_remove(self, ctx: commands.Context, index: int):
+        """!kazhelp
+
+        description: |
+            Remove a scheduled message.
+
+            WARNING: This command cannot be undone.
+        parameters:
+            - name: index
+              type: int
+              description: The number of the reminder to remove. See the {{!saylater list}} command
+                  for the numbered list.
+        examples:
+            - command: .saylater rem 4
+              description: Removes message number 4.
+        """
+        if index <= 0:
+            await self.send_message(ctx.message.channel, ctx.message.author.mention +
+                " Oops, that scheduled message doesn't exist!")
+            return
+        try:
+            reminder = self.saylaters[index-1]
+        except IndexError:
+            await self.send_message(ctx.message.channel, ctx.message.author.mention +
+                 " Oops, that message doesn't exist! You only have {:d} messages scheduled."
+                 .format(len(self.saylaters)))
+            return
+
+        desc = "Removed scheduled message "\
+               "in {channel} for {remind_time} UTC (in {delta}): {message}".format(
+                    delta=format_timedelta(reminder.remind_time - datetime.utcnow()),
+                    **reminder.str_dict()
+                )
+
+        self.remove_reminder(reminder)
+        await self.send_message(ctx.message.channel, ctx.message.author.mention + " " + desc)
 
 
 def setup(bot):

--- a/kaztron/cog/resource_channel.py
+++ b/kaztron/cog/resource_channel.py
@@ -32,6 +32,7 @@ class ResourceChannelConfig(SectionView):
     allow_re_strings: List[Pattern]
     deny_strings: List[str]
     deny_re_strings: List[Pattern]
+    allow_uploads: bool
 
 
 class ResourceChannelManager(KazCog):
@@ -59,7 +60,8 @@ class ResourceChannelManager(KazCog):
             allow_strings=('http://', 'https://'),
             allow_re_strings=tuple(),
             deny_strings=tuple(),
-            deny_re_strings=tuple()
+            deny_re_strings=tuple(),
+            allow_uploads=True
         )
         self.cog_config.set_converters('channel', lambda id_: self.get_channel(id_), None)
         self.cog_config.set_converters('allow_re_strings',
@@ -99,6 +101,8 @@ class ResourceChannelManager(KazCog):
             return False
         if any(p.search(message.content) is not None for p in self.cog_config.deny_re_strings):
             return False
+        if self.cog_config.allow_uploads and message.attachments:
+            return True
         if any(s in message.content for s in self.cog_config.allow_strings):
             return True
         if any(p.search(message.content) is not None for p in self.cog_config.allow_re_strings):

--- a/kaztron/cog/resource_channel.py
+++ b/kaztron/cog/resource_channel.py
@@ -61,7 +61,7 @@ class ResourceChannelManager(KazCog):
             deny_strings=tuple(),
             deny_re_strings=tuple()
         )
-        self.cog_config.set_converters('channel', lambda id_: self.validate_channel(id_), None)
+        self.cog_config.set_converters('channel', lambda id_: self.get_channel(id_), None)
         self.cog_config.set_converters('allow_re_strings',
                                        lambda l: list(re.compile(s) for s in l), None)
         self.cog_config.set_converters('deny_re_strings',

--- a/kaztron/cog/resource_channel.py
+++ b/kaztron/cog/resource_channel.py
@@ -73,7 +73,13 @@ class ResourceChannelManager(KazCog):
     @ready_only
     async def on_message(self, message: discord.Message):
         """ Message handler. Auto-upvotes valid resource messages. """
-        if message.channel.id != self.cog_config.channel.id:
+
+        # resource channel only
+        if message.channel != self.cog_config.channel:
+            return
+
+        # don't react to self
+        if message.author == self.bot.user:
             return
 
         if not self.is_resource_post(message):

--- a/kaztron/cog/resource_channel.py
+++ b/kaztron/cog/resource_channel.py
@@ -12,18 +12,26 @@ logger = logging.getLogger(__name__)
 
 
 class ResourceChannelConfig(SectionView):
-    channel: discord.Channel                    # ID of the resources channel
-    reactions: List[Union[discord.Emoji, str]]  # list of reactions to add to identified resources
-    allow_strings: List[str]         # messages containing any of these strings are resources
-    allow_re_strings: List[Pattern]  # messages matching any of these regexes are resources
-    deny_strings: List[str]          # messages containing any of these strings are NOT resources
-    deny_re_strings: List[Pattern]   # messages matching any of these regexes are NOT resources
-
-    # Deny takes precedence over Allow.
-    # The "reactions" list should be either the :name:ID of the custom emoji, or the Unicode emoji
-    # for standard ones. To ensure the correct emoji strings are used, you can
-    # backslash-escape the emoji in Discord and copy the resulting string. (If it comes out as
-    # <:Name:123456789012345678>, then omit the <angle brackets>.)
+    """
+    :ivar channel: Resources channel ID
+    :ivar reactions: list of reactions to add to identified resources. Can be Unicode emoji or
+        custom server emoticon given in the form :name:123456789012345678. (You can backslash-escape
+        the emoticon in Discord to get this form.)
+    :ivar allow_strings: List of strings to search for. Any message containing one or more of these
+        strings is considered a resource message.
+    :ivar allow_re_strings: List of regular expressions to match against. Any message matching one
+        or more of these patterns is considered a resource message.
+    :ivar deny_strings: List of strings to search for to EXCLUDE a message as a resource. This takes
+        priority over the "allow" configurations.
+    :ivar deny_re_strings: List of regular expressions to match against to EXCLUDE a message as a
+        resource. This takes priority over the "allow" configurations.
+    """
+    channel: discord.Channel
+    reactions: List[Union[discord.Emoji, str]]
+    allow_strings: List[str]
+    allow_re_strings: List[Pattern]
+    deny_strings: List[str]
+    deny_re_strings: List[Pattern]
 
 
 class ResourceChannelManager(KazCog):

--- a/kaztron/cog/spotlight.py
+++ b/kaztron/cog/spotlight.py
@@ -518,7 +518,7 @@ class Spotlight(KazCog):
         """ Load information from the server. """
         await super().on_ready()
 
-        self.channel_spotlight = self.validate_channel(self.ch_id_spotlight)
+        self.channel_spotlight = self.get_channel(self.ch_id_spotlight)
 
         try:
             self.rolemanager.add_managed_role(

--- a/kaztron/cog/sprint/sprint.py
+++ b/kaztron/cog/sprint/sprint.py
@@ -413,7 +413,7 @@ class WritingSprint(KazCog):
         await super().on_ready()
 
         logger.debug("Validating sprint channel...")
-        self.channel = self.validate_channel(self.channel_id)
+        self.channel = self.get_channel(self.channel_id)
 
         try:
             self.rolemanager.add_managed_role(

--- a/kaztron/cog/sticky.py
+++ b/kaztron/cog/sticky.py
@@ -365,7 +365,10 @@ class Sticky(KazCog):
                 List all configured sticky messages.
         """
         sorted_data = sorted(self.cog_state.messages.values(), key=lambda v: v.channel.name)
-        es = EmbedSplitter(title="Channel Sticky Messages")
+        if sorted_data:
+            es = EmbedSplitter(title="Channel Sticky Messages")
+        else:
+            es = EmbedSplitter(title="Channel Sticky Messages", description="None.")
         for data in sorted_data:
             try:
                 jump_url = ' *([link]({}))*'.format(

--- a/kaztron/cog/voicelog.py
+++ b/kaztron/cog/voicelog.py
@@ -76,8 +76,8 @@ class VoiceLog(KazCog):
         self.channel_map = {}
         for voice_cid, text_cid in self.cog_config.voice_text_channel_map.items():
             try:
-                voice_ch = self.validate_channel(voice_cid)
-                text_ch = self.validate_channel(text_cid)
+                voice_ch = self.get_channel(voice_cid)
+                text_ch = self.get_channel(text_cid)
             except ValueError:
                 msg = "Failed to find one or both channels for voicelog: voice={!r} text={!r}"\
                     .format(voice_cid, text_cid)

--- a/kaztron/cog/welcome.py
+++ b/kaztron/cog/welcome.py
@@ -39,7 +39,7 @@ class Welcome(KazCog):
 
     async def on_ready(self):
         await super().on_ready()
-        self.channel_welcome = self.validate_channel(self.cog_config.channel_welcome)
+        self.channel_welcome = self.get_channel(self.cog_config.channel_welcome)
 
     def export_kazhelp_vars(self):
         return {'welcome_channel': '#' + self.channel_welcome.name}

--- a/kaztron/cog/wordfilter.py
+++ b/kaztron/cog/wordfilter.py
@@ -10,7 +10,7 @@ from kaztron.driver.wordfilter import WordFilter as WordFilterEngine
 from kaztron.kazcog import ready_only
 from kaztron.utils.checks import mod_only, mod_channels
 from kaztron.utils.discord import check_role, MSG_MAX_LEN, Limits, get_command_str, get_help_str, \
-    get_group_help
+    get_group_help, get_jump_url
 from kaztron.utils.logging import message_log_str
 from kaztron.utils.strings import format_list, split_code_chunks_on, natural_truncate
 
@@ -150,7 +150,7 @@ class WordFilter(KazCog):
         return {'warn_channel': '#' + self.channel_warning.name}
 
     @ready_only
-    async def on_message(self, message):
+    async def on_message(self, message: discord.Message):
         """
         Message handler. Check all non-mod messages for filtered words.
         """
@@ -188,6 +188,9 @@ class WordFilter(KazCog):
                 em.add_field(name="Channel", value=message.channel.mention, inline=True)
                 em.add_field(name="Timestamp", value=format_timestamp(message), inline=True)
                 em.add_field(name="Match Text", value=match_text, inline=True)
+                em.add_field(name="Message Link",
+                             value='[Message link]({})'.format(get_jump_url(message)),
+                             inline=True)
                 em.add_field(name="Content",
                              value=natural_truncate(message_string, Limits.EMBED_FIELD_VALUE),
                              inline=False)

--- a/kaztron/cog/wordfilter.py
+++ b/kaztron/cog/wordfilter.py
@@ -120,10 +120,10 @@ class WordFilter(KazCog):
             channel=self.cog_config.channel_warning
         )
         self.cog_config.set_converters('channel_warning',
-            lambda cid: self.validate_channel(cid),
+            lambda cid: self.get_channel(cid),
             lambda _: None)
         self.cog_state.set_converters('channel',
-            lambda cid: self.validate_channel(cid),
+            lambda cid: self.get_channel(cid),
             lambda c: str(c.id))
         self._load_filter_rules()
         self.channel_warning = None

--- a/kaztron/config.py
+++ b/kaztron/config.py
@@ -343,6 +343,7 @@ class SectionView:
         """ Read a configuration value. Usage is similar to :meth:`KaztronConfig.get`. """
         converter = self.__converters.get(key, (None, None))[0]
         if key in self.__cache:
+            logger.debug("{!s}: Read key '{}' from converter cache.".format(self, key))
             return self.__cache[key]
         else:
             value = self.__config.get(self.__section, key, default=default, converter=converter)
@@ -359,6 +360,11 @@ class SectionView:
 
     def keys(self):
         return self.__config.get_section_data(self.__section).keys()
+
+    def clear_cache(self):
+        """ Clear the converted value cache. """
+        logger.debug("{!s}: Clearing converted value cache.".format(self))
+        self.__cache.clear()
 
     def __str__(self):
         return "{!s}:{}".format(self.__config, self.__section)

--- a/kaztron/core.py
+++ b/kaztron/core.py
@@ -199,12 +199,13 @@ class CoreCog(kaztron.KazCog):
             logger.warning("Event {} called before on_ready: ignoring".format(event))
             return
 
-        log_msg = "Error occurred in {}({}, {})".format(
+        log_msg = "{}({}, {})".format(
             event,
             ', '.join(repr(arg) for arg in args),
             ', '.join(key + '=' + repr(value) for key, value in kwargs.items()))
-        logger.exception(log_msg)
-        await self.send_output("[ERROR] {} - see logs for details".format(exc_log_str(exc_info[1])))
+        logger.exception("Error occurred in " + log_msg)
+        await self.send_output("[ERROR] In {}\n\n{}\n\nSee log for details".format(
+            log_msg, exc_log_str(exc_info[1])))
 
         try:
             message = args[0]

--- a/kaztron/core.py
+++ b/kaztron/core.py
@@ -52,15 +52,15 @@ class CoreCog(kaztron.KazCog):
     def __init__(self, bot):
         super().__init__(bot, 'core')
         self.cog_config = self.cog_config  # type: CoreConfig
-        self.cog_config.set_converters('channel_request', self.validate_channel, lambda c: c.id)
+        self.cog_config.set_converters('channel_request', self.get_channel, lambda c: c.id)
         self.name = self.cog_config.name
 
         self.bot.event(self.on_error)  # register this as a global event handler, not just local
-        self.bot.add_check(self.check_bot_ready)
+        self.bot.add_check(self._check_bot_ready)
         self.ready_cogs = set()
         self.error_cogs = set()
 
-    def check_bot_ready(self, ctx: commands.Context):
+    def _check_bot_ready(self, ctx: commands.Context):
         """ Check if bot is ready. Used as a global check. """
         if ctx.cog is not None:
             if ctx.cog in self.ready_cogs:
@@ -390,7 +390,7 @@ class CoreCog(kaztron.KazCog):
                 cog_name = exc.args[0]
             except IndexError:
                 cog_name = 'unknown'
-            logger.warning("Attempted to use command on cog in error state: {}".format(cmd_string))
+            logger.error("Attempted to use command on cog in error state: {}".format(cmd_string))
             await self.bot.send_message(
                 ctx.message.channel, author_mention +
                 "Sorry, an error occurred loading the {} module! Please let a mod/admin know."

--- a/kaztron/errors.py
+++ b/kaztron/errors.py
@@ -1,6 +1,5 @@
 from discord.ext import commands
 
-
 class DiscordErrorCodes:
     # https://discordapp.com/developers/docs/topics/opcodes-and-status-codes
     CANNOT_PM_USER = 50007
@@ -11,6 +10,10 @@ class BotNotReady(commands.CommandError):
 
 
 class BotCogError(commands.CommandError):
+    pass
+
+
+class CogNotLoadedError(RuntimeError):
     pass
 
 

--- a/kaztron/help_formatter.py
+++ b/kaztron/help_formatter.py
@@ -596,6 +596,7 @@ class JekyllHelpFormatter:
             data = self.parser.parse(cog, self.bot)
         except NotKazhelpError as e:
             data = {
+                'category': '',
                 'brief': None,
                 'description': cog.__doc__ or '',
                 'jekyll_description': None,

--- a/kaztron/kazcog.py
+++ b/kaztron/kazcog.py
@@ -79,6 +79,10 @@ class KazCog:
             @functools.wraps(f)
             async def wrapper(cog):
                 try:
+                    if cog.cog_state:
+                        cog.cog_config.clear_cache()
+                    if cog.cog_state:
+                        cog.cog_state.clear_cache()
                     await f()
                 except Exception:
                     cog.core.set_cog_error(cog)

--- a/kaztron/kazcog.py
+++ b/kaztron/kazcog.py
@@ -164,6 +164,8 @@ class KazCog:
 
         Variable names must start with a character in the set [A-Za-z0-9_].
 
+        Variable values must be strings.
+
         :return: variable name -> value
         """
         return {}

--- a/kaztron/scheduler.py
+++ b/kaztron/scheduler.py
@@ -138,7 +138,6 @@ class TaskInstance:
         except (asyncio.CancelledError, KeyboardInterrupt, SystemExit):
             raise
         except Exception as e:
-            logger.exception("Error in Task {!s}.".format(task_id))
             try:
                 await self.on_error(e)
             except Exception:

--- a/kaztron/utils/datetime.py
+++ b/kaztron/utils/datetime.py
@@ -108,21 +108,22 @@ def format_timedelta(delta: timedelta, timespec="seconds") -> str:
     str_parts = []
 
     timespec_list = ['days', 'hours', 'minutes', 'seconds', 'microseconds']
-    timespec_prio = timespec_list.index(timespec)
+    try:
+        timespec_prio = timespec_list.index(timespec)
 
-    # get a resolution object to round against
-    if timespec == 'days':
-        res = timedelta(days=1)
-    elif timespec == 'hours':
-        res = timedelta(hours=1)
-    elif timespec == 'minutes':
-        res = timedelta(minutes=1)
-    elif timespec == 'seconds':
-        res = timedelta(seconds=1)
-    elif timespec == 'microseconds':
-        res = None
-    else:
-        raise ValueError("Invalid timespec")
+        # get a resolution object to round against
+        if timespec == 'days':
+            res = timedelta(days=1)
+        elif timespec == 'hours':
+            res = timedelta(hours=1)
+        elif timespec == 'minutes':
+            res = timedelta(minutes=1)
+        elif timespec == 'seconds':
+            res = timedelta(seconds=1)
+        elif timespec == 'microseconds':
+            res = None
+    except ValueError:
+            raise ValueError("Invalid timespec {!r}".format(timespec)) from None
 
     # round
     if res:

--- a/kaztron/utils/discord.py
+++ b/kaztron/utils/discord.py
@@ -316,3 +316,17 @@ def get_group_help(ctx: commands.Context):
     return ('Invalid sub-command. Valid subcommands are `{0!s}`. '
             'Use `{1}` or `{1} <subcommand>` for instructions.') \
         .format(subcommand_list, get_help_str(ctx))
+
+
+def get_jump_url(message: discord.Message):
+    """
+    Gets the direct URL to a message.
+
+    Deprecate this once we upgrade to Discord 1.0.0, jump_url is an available attribute there
+    :param message:
+    :return:
+    """
+    message.channel: discord.Channel
+    return 'https://discordapp.com/channels/{}/{}/{}'.format(
+        message.channel.server.id, message.channel.id, message.id
+    )

--- a/kaztron/utils/embeds.py
+++ b/kaztron/utils/embeds.py
@@ -34,6 +34,7 @@ class EmbedSplitter:
         self.repeat_header = repeat_header
         self.repeat_footer = repeat_footer
         self.repeat_image = repeat_image
+        self.cur_num_fields = 0
 
         if title is not EmptyEmbed and len(title) > Limits.EMBED_TITLE:
             if not self.auto_truncate:

--- a/kaztron/utils/strings.py
+++ b/kaztron/utils/strings.py
@@ -91,7 +91,7 @@ def none_wrapper(value, default=""):
     return value if value is not None else default
 
 
-_KWARG_RE = re.compile('\s*([A-Za-z0-9_-]+)=("[^"]+"|[^ ]+)(\s*.*)')
+_KWARG_RE = re.compile('\s*([A-Za-z0-9_-]+)=("[^"]+"|[^ ]+)(\s*.*)', flags=re.DOTALL)
 
 
 def parse_keyword_args(keywords: Iterable[str], args: str) -> (Dict[str, str], str):


### PR DESCRIPTION
# Changelog

## New modules

* **resource_channel**: Automated tools for #resource channel management on Worldbuilding. For now, automatic upvoting of messages detected as resource posts. #270 (bugs: #319, #320)
* **sticky**: Moderator tool. Automatically maintains a message at the bottom of a channel, with configurable delay before renewing the message (to avoid interrupting ongoing conversation). A more visible "sticky" message compared to pins or channel topics. #312 (bugs: #321)
* **discordtools**: Miscellaneous tools to help with Discord usage.
  * `.id`: Allows users to get their own ID. Purely convenience, since users could always @mention themselves and prepend an escape character `\` before, but instructing them to do this is cumbersome. #276 
  * `.kaztime` (`.time` and `.now`): Get the current KazTron time. This is UTC and can be useful for users to figure out the community programmes schedule on WB. #292 
* **modnotes.bantools**
  * Move some modtools into its own module.
  * Validation of permaban records against current userlist. #294 
  * Command to force immediate update of temp and permaban enforcement. #302 
  * With `modnotes.bantools` enabled, modnotes will automatically reevaluate bans when a change is committed to modnotes. #302 (ish, this resolves one of the underlying reasons for #302)
* **modnotes.jointools**: Add feature to track user join/parts in modtools, not only in bot channel. #272 

## New features

* **wordfilter**: Add message "jump" link in mod notification embed. #271
* **modtools, reminders**: `.say` and .`saylater` can now auto-pin. #324 

## Enhancements and bug fixes

* **modnotes**
  * Extend record IDs to 5 digits, user IDs to 4 digits. #205 
  * Fix bug when adding records that use both keyword args and newlines in the message, where the message would be truncated at the newline. #281 
  * Allow name#0000 lookups (without a mention), to address some issues with modnotes use while on mobile Discord apps. #197 
* **modnotes.bantools**:
  * Fix unclear error messages when bot is unable to enforce a tempban role due to permissions. #303 
  * Show KazTron ID number in ban/unban message. #323 

## Core bug fixes

* Fix bug in keyword parser regex that ignored newlines. #281 
* Adjust logging levels in the core to reduce unnecessary log verbosity.
* **KazCog**: Fix that `send_message()` and variant methods do not return the posted message object(s).
* **config**:
  * Add caching to SectionView for converted values. (Subsequent bug: #322)
  * Allow SectionView converter to be None (to avoid needing to specify `lambda x: None` or similar for the write converter of read-only converters).
* **docs**: Fix jekyllate failure when a cog did not contain kazhelp or was missing the `category` field. #325 
* **EmbedSplitter**: Fix AttributeError when no fields defined in EmbedSplitter.