### PR TITLE
v2.5.1

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" default="true" project-jdk-name="Python 3.6.3 virtualenv at ~/.virtualenvs/kaztron" project-jdk-type="Python SDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" default="true" project-jdk-name="Python 3.6 (kaztron36)" project-jdk-type="Python SDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/kaztron/__init__.py
+++ b/kaztron/__init__.py
@@ -4,7 +4,7 @@ from .kazcog import KazCog
 from .scheduler import Scheduler, TaskInstance, task
 
 __release__ = "2.5"  # release stream, usually major.minor only
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 
 bot_info = {
     "version": __version__,

--- a/kaztron/cog/spotlight.py
+++ b/kaztron/cog/spotlight.py
@@ -348,8 +348,7 @@ class Spotlight(KazCog):
         self.state.set('spotlight', 'queue', list(self.queue_data))
         self.state.set('spotlight', 'start_time',
             utctimestamp(self.start_time) if self.start_time is not None else None)
-        self.state.set('spotlight', 'reminders',
-            [utctimestamp(t) for t in self.reminders])
+        self.state.set('spotlight', 'reminders', [utctimestamp(t) for t in self.reminders])
         self.state.write()
 
     def _upgrade_queue_v21(self):
@@ -1330,6 +1329,7 @@ class Spotlight(KazCog):
         self.reminders = deque(self.start_time + timedelta(seconds=offset)
                                for offset in self.reminder_offsets)
         self._schedule_reminders()
+        self._write_db()
 
     def _schedule_reminders(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ ruamel.yaml~=0.16.0
 google-api-python-client~=1.7.10
 oauth2client~=4.1.2
 asyncpraw~=7.1.0
-aiohttp~=3.6


### PR DESCRIPTION
Bugfix release.

Fixes:

* [subwatch] In some conditions, SubWatch would reset position in the /new queue and repost earlier posts (#339)
* [subwatch] On adding a Discord channel's subwatches, old posts on the /new queue were queued immediately (#340)
* [subwatch] Added a reset command to allow moderators to deal with bugs like #339 
* [subwatch] Changes to subwatches not saved to disk in some conditions
* [subwatch] Too many redundant log lines (#338)
* [spotlight] Spotlight state (timer, start/stop/time features) not saved to disk in some conditions